### PR TITLE
Context is not a Singleton anymore.

### DIFF
--- a/include/context.hpp
+++ b/include/context.hpp
@@ -45,13 +45,11 @@ namespace powerloader
 
         std::vector<std::string> additional_httpheaders;
 
-        static Context& instance();
-
         void set_verbosity(int v);
 
-    private:
+        // Throws if another instance already exists: there can only be one at any time!
         Context();
-        ~Context() = default;
+        ~Context();
 
         Context(const Context&) = delete;
         Context& operator=(const Context&) = delete;

--- a/include/curl.hpp
+++ b/include/curl.hpp
@@ -17,6 +17,8 @@
 
 namespace powerloader
 {
+    class Context;
+
     extern "C"
     {
 #include <curl/curl.h>
@@ -47,14 +49,14 @@ namespace powerloader
     };
 
     // TODO: rename this, try to not expose it
-    CURL* get_handle();
+    CURL* get_handle(const Context& ctx);
 
     class CURLHandle
     {
     public:
         using end_callback_type = std::function<CbReturnCode(const Response&)>;
-        CURLHandle();
-        CURLHandle(const std::string& url);
+        explicit CURLHandle(const Context& ctx);
+        CURLHandle(const Context& ctx, const std::string& url);
         ~CURLHandle();
 
         CURLHandle& url(const std::string& url);
@@ -98,7 +100,7 @@ namespace powerloader
 
     // TODO: restrict the possible implementations in the cpp file
     template <class T>
-    inline CURLHandle& CURLHandle::setopt(CURLoption opt, const T& val)
+    CURLHandle& CURLHandle::setopt(CURLoption opt, const T& val)
     {
         CURLcode ok;
         if constexpr (std::is_same<T, std::string>())

--- a/include/downloader.hpp
+++ b/include/downloader.hpp
@@ -33,10 +33,12 @@ namespace powerloader
 {
     namespace fs = std::filesystem;
 
+    class Context;
+
     class Downloader
     {
     public:
-        Downloader();
+        explicit Downloader(const Context& ctx);
         ~Downloader();
 
         void add(const std::shared_ptr<DownloadTarget>& dl_target);
@@ -83,6 +85,7 @@ namespace powerloader
 
         bool failfast = false;
         CURLM* multi_handle;
+        const Context& ctx;
 
         std::vector<Target*> m_targets;
         std::vector<Target*> m_running_transfers;

--- a/include/fastest_mirror.hpp
+++ b/include/fastest_mirror.hpp
@@ -6,7 +6,9 @@
 
 namespace powerloader
 {
-    void fastest_mirror(const std::vector<std::string>& urls);
+    class Context;
+
+    void fastest_mirror(const Context& ctx, const std::vector<std::string>& urls);
 }
 
 #endif

--- a/include/mirror.hpp
+++ b/include/mirror.hpp
@@ -18,6 +18,7 @@
 namespace powerloader
 {
     class Target;
+    class Context;
 
     enum class MirrorState
     {
@@ -32,7 +33,7 @@ namespace powerloader
     // mirrors should be dict -> urls mapping
     struct Mirror
     {
-        Mirror(const std::string& url);
+        Mirror(const Context& ctx, const std::string& url);
         virtual ~Mirror() = default;
 
         Mirror(const Mirror&) = delete;

--- a/include/mirrors/oci.hpp
+++ b/include/mirrors/oci.hpp
@@ -22,8 +22,9 @@ namespace powerloader
         using split_function_type
             = std::function<std::pair<std::string, std::string>(const std::string&)>;
 
-        OCIMirror(const std::string& host, const std::string& repo_prefix);
-        OCIMirror(const std::string& host,
+        OCIMirror(const Context& ctx, const std::string& host, const std::string& repo_prefix);
+        OCIMirror(const Context& ctx,
+                  const std::string& host,
                   const std::string& repo_prefix,
                   const std::string& scope,
                   const std::string& username,
@@ -86,7 +87,7 @@ namespace powerloader
                                     const std::optional<nlohmann::json>& annotations
                                     = std::nullopt);
 
-        Response upload(const OCIMirror& mirror, const std::string& reference) const;
+        Response upload(const Context& ctx, const OCIMirror& mirror, const std::string& reference) const;
 
         nlohmann::json to_json() const;
 
@@ -97,7 +98,8 @@ namespace powerloader
                  const std::optional<nlohmann::json>& annotations = std::nullopt);
     };
 
-    Response oci_upload(OCIMirror& mirror,
+    Response oci_upload(const Context& ctx,
+                        OCIMirror& mirror,
                         const std::string& reference,
                         const std::string& tag,
                         const std::vector<OCILayer>& layers,

--- a/include/mirrors/oci.hpp
+++ b/include/mirrors/oci.hpp
@@ -87,7 +87,9 @@ namespace powerloader
                                     const std::optional<nlohmann::json>& annotations
                                     = std::nullopt);
 
-        Response upload(const Context& ctx, const OCIMirror& mirror, const std::string& reference) const;
+        Response upload(const Context& ctx,
+                        const OCIMirror& mirror,
+                        const std::string& reference) const;
 
         nlohmann::json to_json() const;
 

--- a/include/mirrors/s3.hpp
+++ b/include/mirrors/s3.hpp
@@ -35,12 +35,13 @@ namespace powerloader
     class S3Mirror : public Mirror
     {
     public:
-        S3Mirror(const std::string& bucket_url,
+        S3Mirror(const Context& ctx,
+                 const std::string& bucket_url,
                  const std::string& region,
                  const std::string& aws_access_key,
                  const std::string& aws_secret_key);
 
-        S3Mirror(const std::string& url);
+        S3Mirror(const Context& ctx, const std::string& url);
 
         bool authenticate(CURLHandle& handle, const std::string& path) override;
         std::string format_url(Target* target) override;
@@ -63,7 +64,7 @@ namespace powerloader
         std::string region = "eu-central-1";
     };
 
-    Response s3_upload(S3Mirror& mirror, const std::string& path, const fs::path& file);
+    Response s3_upload(const Context& ctx, S3Mirror& mirror, const std::string& path, const fs::path& file);
 }
 
 #endif

--- a/include/mirrors/s3.hpp
+++ b/include/mirrors/s3.hpp
@@ -64,7 +64,10 @@ namespace powerloader
         std::string region = "eu-central-1";
     };
 
-    Response s3_upload(const Context& ctx, S3Mirror& mirror, const std::string& path, const fs::path& file);
+    Response s3_upload(const Context& ctx,
+                       S3Mirror& mirror,
+                       const std::string& path,
+                       const fs::path& file);
 }
 
 #endif

--- a/include/target.hpp
+++ b/include/target.hpp
@@ -34,7 +34,8 @@ namespace powerloader
                                           std::size_t nitems,
                                           Target* self);
 
-        Target(const Context& ctx, std::shared_ptr<DownloadTarget> dl_target,
+        Target(const Context& ctx,
+               std::shared_ptr<DownloadTarget> dl_target,
                std::vector<std::shared_ptr<Mirror>> mirrors = {});
 
         ~Target();

--- a/include/target.hpp
+++ b/include/target.hpp
@@ -34,10 +34,8 @@ namespace powerloader
                                           std::size_t nitems,
                                           Target* self);
 
-        Target(const std::shared_ptr<DownloadTarget>& dl_target);
-
-        Target(const std::shared_ptr<DownloadTarget>& dl_target,
-               const std::vector<std::shared_ptr<Mirror>>& mirrors);
+        Target(const Context& ctx, std::shared_ptr<DownloadTarget> dl_target,
+               std::vector<std::shared_ptr<Mirror>> mirrors = {});
 
         ~Target();
 
@@ -85,7 +83,7 @@ namespace powerloader
         std::size_t writecb_received;
         bool writecb_required_range_written;
 
-        char errorbuffer[CURL_ERROR_SIZE];
+        char errorbuffer[CURL_ERROR_SIZE] = {};
 
         using end_callback = DownloadTarget::end_callback;
         end_callback override_endcb;
@@ -98,6 +96,8 @@ namespace powerloader
 
         bool range_fail = false;
         ZckState zck_state;
+
+        const Context& ctx;
     };
 }
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -117,7 +117,7 @@ oci_fn_split_tag(const std::string& fn)
 }
 
 int
-handle_upload(const std::vector<std::string>& files, const std::vector<std::string>& mirrors)
+handle_upload(const Context& ctx, const std::vector<std::string>& files, const std::vector<std::string>& mirrors)
 {
     std::string mirror_url = mirrors[0];
     if (mirrors.size() > 1)
@@ -154,11 +154,12 @@ handle_upload(const std::vector<std::string>& files, const std::vector<std::stri
             std::string GH_SECRET = get_env("GHA_PAT", "");
             std::string GH_USER = get_env("GHA_USER", "");
 
-            OCIMirror mirror(url.url(), GH_USER, "push", GH_USER, GH_SECRET);
+            OCIMirror mirror{ctx, url.url(), GH_USER, "push", GH_USER, GH_SECRET};
             try
             {
                 auto res
-                    = oci_upload(mirror,
+                    = oci_upload(ctx,
+                                 mirror,
                                  dest,
                                  elems[2],
                                  { OCILayer::from_file("application/octet-stream", elems[0]) });
@@ -196,10 +197,10 @@ handle_upload(const std::vector<std::string>& files, const std::vector<std::stri
             if (url_.back() == '/')
                 url_ = url_.substr(0, url_.size() - 1);
 
-            S3Mirror s3mirror(url_, aws_region, aws_ackey, aws_sekey);
+            S3Mirror s3mirror{ctx, url_, aws_region, aws_ackey, aws_sekey};
             try
             {
-                s3_upload(s3mirror, elems[1], elems[0]);
+                s3_upload(ctx, s3mirror, elems[1], elems[0]);
                 std::cout << "Finished upload for " << f << " to S3 bucket at" << url_ << std::endl;
             }
             catch (std::exception& e)
@@ -224,7 +225,8 @@ struct DownloadMetadata
 };
 
 int
-handle_download(const std::vector<std::string>& urls,
+handle_download(Context& ctx,
+                const std::vector<std::string>& urls,
                 const std::vector<std::string>& mirrors,
                 bool resume,
                 const std::string& dest_folder,
@@ -234,8 +236,6 @@ handle_download(const std::vector<std::string>& urls,
     // the format for URLs is: <mirror>:<path> (e.g. conda-forge:linux-64/xtensor-123.tar.bz2) or
     // https://conda.anaconda.org/conda-forge/linux-64/xtensor-123.tar.bz2
     std::vector<std::shared_ptr<DownloadTarget>> targets;
-
-    auto& ctx = Context::instance();
 
     for (auto& x : urls)
     {
@@ -256,7 +256,7 @@ handle_download(const std::vector<std::string>& urls,
             {
                 ctx.mirror_map[host] = std::vector<std::shared_ptr<Mirror>>();
             }
-            ctx.mirror_map[host].push_back(std::make_shared<Mirror>(mirror_url));
+            ctx.mirror_map[host].push_back(std::make_shared<Mirror>(ctx, mirror_url));
             targets.emplace_back(new DownloadTarget(path.substr(1, std::string::npos), host, dst));
         }
         else
@@ -301,7 +301,7 @@ handle_download(const std::vector<std::string>& urls,
             = std::bind(&progress_callback, targets.back().get(), _1, _2);
     }
 
-    Downloader dl;
+    Downloader dl{ ctx };
     dl.mirror_map = ctx.mirror_map;
 
     for (auto& t : targets)
@@ -335,7 +335,7 @@ handle_download(const std::vector<std::string>& urls,
 }
 
 std::map<std::string, std::vector<std::shared_ptr<Mirror>>>
-parse_mirrors(const YAML::Node& node)
+parse_mirrors(const Context& ctx, const YAML::Node& node)
 {
     assert(node.IsMap());
     std::map<std::string, std::vector<std::shared_ptr<Mirror>>> res;
@@ -408,23 +408,24 @@ parse_mirrors(const YAML::Node& node)
             {
                 spdlog::info("Adding S3 mirror: {} -> {}", mirror_name, creds.url.url());
                 res[mirror_name].emplace_back(
-                    new S3Mirror(creds.url.url(), creds.region, creds.user, creds.password));
+                    new S3Mirror{ctx, creds.url.url(), creds.region, creds.user, creds.password});
             }
             else if (kof == KindOf::kOCI)
             {
                 spdlog::info("Adding OCI mirror: {} -> {}", mirror_name, creds.url.url());
                 if (!creds.password.empty())
                 {
-                    res[mirror_name].emplace_back(new OCIMirror(creds.url.url_without_path(),
+                    res[mirror_name].emplace_back(new OCIMirror{ctx,
+                                                                creds.url.url_without_path(),
                                                                 creds.url.path(),
                                                                 "pull",
                                                                 creds.user,
-                                                                creds.password));
+                                                                creds.password});
                 }
                 else
                 {
                     res[mirror_name].emplace_back(
-                        new OCIMirror(creds.url.url_without_path(), creds.url.path()));
+                        new OCIMirror{ctx, creds.url.url_without_path(), creds.url.path()});
                 }
                 std::dynamic_pointer_cast<OCIMirror>(res[mirror_name].back())
                     ->set_fn_tag_split_function(oci_fn_split_tag);
@@ -432,7 +433,7 @@ parse_mirrors(const YAML::Node& node)
             else if (kof == KindOf::kHTTP)
             {
                 spdlog::info("Adding HTTP mirror: {} -> {}", mirror_name, creds.url.url());
-                res[mirror_name].emplace_back(std::make_shared<Mirror>(creds.url.url()));
+                res[mirror_name].emplace_back(std::make_shared<Mirror>(ctx, creds.url.url()));
             }
         }
     }
@@ -489,12 +490,14 @@ main(int argc, char** argv)
 
     CLI11_PARSE(app, argc, argv);
 
+    powerloader::Context ctx;
+
     if (verbose)
     {
         show_progress_bars = false;
-        Context::instance().set_verbosity(1);
+        ctx.set_verbosity(1);
     }
-    Context::instance().disable_ssl = disable_ssl;
+    ctx.disable_ssl = disable_ssl;
 
     std::vector<Mirror> mlist;
     if (!file.empty())
@@ -502,22 +505,20 @@ main(int argc, char** argv)
         spdlog::info("Loading file {}", file);
         YAML::Node config = YAML::LoadFile(file);
 
-        auto& ctx = Context::instance();
-
         du_files = config["targets"].as<std::vector<std::string>>();
         if (config["mirrors"])
         {
             spdlog::info("Loading mirrors", file);
-            ctx.mirror_map = parse_mirrors(config["mirrors"]);
+            ctx.mirror_map = parse_mirrors(ctx, config["mirrors"]);
         }
     }
     if (app.got_subcommand("upload"))
     {
-        return handle_upload(du_files, mirrors);
+        return handle_upload(ctx, du_files, mirrors);
     }
     if (app.got_subcommand("download"))
     {
-        return handle_download(du_files, mirrors, resume, outdir, dl_meta, do_zck_extract);
+        return handle_download(ctx, du_files, mirrors, resume, outdir, dl_meta, do_zck_extract);
     }
 
     return 0;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -117,7 +117,9 @@ oci_fn_split_tag(const std::string& fn)
 }
 
 int
-handle_upload(const Context& ctx, const std::vector<std::string>& files, const std::vector<std::string>& mirrors)
+handle_upload(const Context& ctx,
+              const std::vector<std::string>& files,
+              const std::vector<std::string>& mirrors)
 {
     std::string mirror_url = mirrors[0];
     if (mirrors.size() > 1)
@@ -154,7 +156,7 @@ handle_upload(const Context& ctx, const std::vector<std::string>& files, const s
             std::string GH_SECRET = get_env("GHA_PAT", "");
             std::string GH_USER = get_env("GHA_USER", "");
 
-            OCIMirror mirror{ctx, url.url(), GH_USER, "push", GH_USER, GH_SECRET};
+            OCIMirror mirror{ ctx, url.url(), GH_USER, "push", GH_USER, GH_SECRET };
             try
             {
                 auto res
@@ -197,7 +199,7 @@ handle_upload(const Context& ctx, const std::vector<std::string>& files, const s
             if (url_.back() == '/')
                 url_ = url_.substr(0, url_.size() - 1);
 
-            S3Mirror s3mirror{ctx, url_, aws_region, aws_ackey, aws_sekey};
+            S3Mirror s3mirror{ ctx, url_, aws_region, aws_ackey, aws_sekey };
             try
             {
                 s3_upload(ctx, s3mirror, elems[1], elems[0]);
@@ -408,24 +410,24 @@ parse_mirrors(const Context& ctx, const YAML::Node& node)
             {
                 spdlog::info("Adding S3 mirror: {} -> {}", mirror_name, creds.url.url());
                 res[mirror_name].emplace_back(
-                    new S3Mirror{ctx, creds.url.url(), creds.region, creds.user, creds.password});
+                    new S3Mirror{ ctx, creds.url.url(), creds.region, creds.user, creds.password });
             }
             else if (kof == KindOf::kOCI)
             {
                 spdlog::info("Adding OCI mirror: {} -> {}", mirror_name, creds.url.url());
                 if (!creds.password.empty())
                 {
-                    res[mirror_name].emplace_back(new OCIMirror{ctx,
-                                                                creds.url.url_without_path(),
-                                                                creds.url.path(),
-                                                                "pull",
-                                                                creds.user,
-                                                                creds.password});
+                    res[mirror_name].emplace_back(new OCIMirror{ ctx,
+                                                                 creds.url.url_without_path(),
+                                                                 creds.url.path(),
+                                                                 "pull",
+                                                                 creds.user,
+                                                                 creds.password });
                 }
                 else
                 {
                     res[mirror_name].emplace_back(
-                        new OCIMirror{ctx, creds.url.url_without_path(), creds.url.path()});
+                        new OCIMirror{ ctx, creds.url.url_without_path(), creds.url.path() });
                 }
                 std::dynamic_pointer_cast<OCIMirror>(res[mirror_name].back())
                     ->set_fn_tag_split_function(oci_fn_split_tag);

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1,5 +1,7 @@
 #include "context.hpp"
 
+#include <exception>
+
 #ifdef WITH_ZCHUNK
 extern "C"
 {
@@ -9,20 +11,25 @@ extern "C"
 
 namespace powerloader
 {
-    Context& Context::instance()
-    {
-        static Context ctx;
-        return ctx;
-    }
+    static std::atomic<bool> is_context_alive { false };
 
     Context::Context()
     {
+        bool expected = false;
+        if(!is_context_alive.compare_exchange_strong(expected, true))
+            throw std::runtime_error("powerloader::Context created more than once - instance must be unique");
+
         cache_dir = fs::absolute(fs::path(".pdcache"));
         if (!fs::exists(cache_dir))
         {
             fs::create_directories(cache_dir);
         }
         set_verbosity(0);
+    }
+
+    Context::~Context()
+    {
+        is_context_alive = false;
     }
 
     void Context::set_verbosity(int v)

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -11,13 +11,14 @@ extern "C"
 
 namespace powerloader
 {
-    static std::atomic<bool> is_context_alive { false };
+    static std::atomic<bool> is_context_alive{ false };
 
     Context::Context()
     {
         bool expected = false;
-        if(!is_context_alive.compare_exchange_strong(expected, true))
-            throw std::runtime_error("powerloader::Context created more than once - instance must be unique");
+        if (!is_context_alive.compare_exchange_strong(expected, true))
+            throw std::runtime_error(
+                "powerloader::Context created more than once - instance must be unique");
 
         cache_dir = fs::absolute(fs::path(".pdcache"));
         if (!fs::exists(cache_dir))

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -53,10 +53,9 @@ namespace powerloader
      * CURLHandle*
      **************/
 
-    CURL* get_handle()
+    CURL* get_handle(const Context& ctx)
     {
         // TODO: get rid of goto
-        auto& ctx = Context::instance();
         CURL* h = curl_easy_init();
         if (!h)
             return nullptr;
@@ -98,7 +97,7 @@ namespace powerloader
         if (curl_easy_setopt(h, CURLOPT_FILETIME, (long) ctx.preserve_filetime) != CURLE_OK)
             goto err;
 
-        if (Context::instance().verbosity > 0)
+        if (ctx.verbosity > 0)
             if (curl_easy_setopt(h, CURLOPT_VERBOSE, 1) != CURLE_OK)
                 goto err;
 
@@ -109,8 +108,8 @@ namespace powerloader
         return nullptr;
     }
 
-    CURLHandle::CURLHandle()
-        : m_handle(get_handle())
+    CURLHandle::CURLHandle(const Context& ctx)
+        : m_handle(get_handle(ctx))
     {
         if (m_handle == nullptr)
         {
@@ -121,8 +120,8 @@ namespace powerloader
         setopt(CURLOPT_ERRORBUFFER, errorbuffer);
     }
 
-    CURLHandle::CURLHandle(const std::string& url)
-        : CURLHandle()
+    CURLHandle::CURLHandle(const Context& ctx, const std::string& url)
+        : CURLHandle(ctx)
     {
         this->url(url);
     }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -373,8 +373,7 @@ namespace powerloader
             // This condition should never be true for a full_url built from a mirror, because
             // select_suitable_mirror() checks if the URL is local if LRO_OFFLINE is enabled by
             // itself.
-            if (!full_url.empty() && ctx.offline
-                && !starts_with(full_url, "file://"))
+            if (!full_url.empty() && ctx.offline && !starts_with(full_url, "file://"))
             {
                 spdlog::info("Skipping {} because offline mode is active", full_url);
 

--- a/src/fastest_mirror.cpp
+++ b/src/fastest_mirror.cpp
@@ -26,12 +26,12 @@ namespace powerloader
         long HALF_OF_SECOND_IN_MICROS = 500000;
     }
 
-    void fastest_mirror(const std::vector<std::string>& urls)
+    void fastest_mirror(const Context& ctx, const std::vector<std::string>& urls)
     {
         std::vector<detail::InternalMirror> check_mirrors;
         for (const std::string& u : urls)
         {
-            CURL* handle = get_handle();
+            CURL* handle = get_handle(ctx);
 
             int curlcode = curl_easy_setopt(handle, CURLOPT_URL, u.c_str());
             if (curlcode != CURLE_OK)

--- a/src/mirror.cpp
+++ b/src/mirror.cpp
@@ -6,7 +6,7 @@
 
 namespace powerloader
 {
-    Mirror::Mirror(const std::string& url)
+    Mirror::Mirror(const Context& ctx, const std::string& url)
         : url(url)
         , preference(0)
         , protocol(Protocol::kHTTP)
@@ -14,7 +14,6 @@ namespace powerloader
         if (url.back() == '/')
             this->url = this->url.substr(0, this->url.size() - 1);
 
-        auto& ctx = Context::instance();
         if (ctx.max_downloads_per_mirror > 0)
         {
             allowed_parallel_connections = ctx.max_downloads_per_mirror;

--- a/src/mirrors/oci.cpp
+++ b/src/mirrors/oci.cpp
@@ -37,7 +37,9 @@ namespace powerloader
     //     ]
     // }
 
-    OCIMirror::OCIMirror(const Context& ctx, const std::string& host, const std::string& repo_prefix)
+    OCIMirror::OCIMirror(const Context& ctx,
+                         const std::string& host,
+                         const std::string& repo_prefix)
         : Mirror(ctx, host)
         , m_repo_prefix(repo_prefix)
         , m_scope("pull")

--- a/src/mirrors/oci.cpp
+++ b/src/mirrors/oci.cpp
@@ -37,19 +37,20 @@ namespace powerloader
     //     ]
     // }
 
-    OCIMirror::OCIMirror(const std::string& host, const std::string& repo_prefix)
-        : Mirror(host)
+    OCIMirror::OCIMirror(const Context& ctx, const std::string& host, const std::string& repo_prefix)
+        : Mirror(ctx, host)
         , m_repo_prefix(repo_prefix)
         , m_scope("pull")
     {
     }
 
-    OCIMirror::OCIMirror(const std::string& host,
+    OCIMirror::OCIMirror(const Context& ctx,
+                         const std::string& host,
                          const std::string& repo_prefix,
                          const std::string& scope,
                          const std::string& username,
                          const std::string& password)
-        : Mirror(host)
+        : Mirror(ctx, host)
         , m_repo_prefix(repo_prefix)
         , m_scope(scope)
         , m_username(username)

--- a/src/mirrors/s3.cpp
+++ b/src/mirrors/s3.cpp
@@ -107,22 +107,23 @@ namespace powerloader
      * S3Mirror    *
      ***************/
 
-    S3Mirror::S3Mirror(const std::string& bucket_url,
+    S3Mirror::S3Mirror(const Context& ctx,
+                       const std::string& bucket_url,
                        const std::string& region,
                        const std::string& aws_access_key,
                        const std::string& aws_secret_key)
-        : bucket_url(bucket_url)
+        : Mirror(ctx, bucket_url)
+        , bucket_url(bucket_url)
         , region(region)
         , aws_access_key_id(aws_access_key)
         , aws_secret_access_key(aws_secret_key)
-        , Mirror(bucket_url)
     {
         if (bucket_url.back() == '/')
             this->bucket_url = this->bucket_url.substr(0, this->bucket_url.size() - 1);
     }
 
-    S3Mirror::S3Mirror(const std::string& url)
-        : Mirror(url)
+    S3Mirror::S3Mirror(const Context& ctx, const std::string& url)
+        : Mirror(ctx, url)
     {
     }
 

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -29,7 +29,7 @@ PYBIND11_MODULE(pypowerloader, m)
         .def(py::init<const Context&, const std::string&>());
 
     py::class_<Context, std::unique_ptr<Context>>(m, "Context")
-        .def(py::init([]{ return std::make_unique<Context>(); }))
+        .def(py::init([] { return std::make_unique<Context>(); }))
         .def_readwrite("verbosity", &Context::verbosity)
         .def_readwrite("mirror_map", &Context::mirror_map);
 

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -25,16 +25,16 @@ PYBIND11_MODULE(pypowerloader, m)
         .def_readonly("complete_url", &DownloadTarget::complete_url)
         .def_readwrite("progress_callback", &DownloadTarget::progress_callback);
 
-    py::class_<Mirror, std::shared_ptr<Mirror>>(m, "Mirror").def(py::init<const std::string&>());
+    py::class_<Mirror, std::shared_ptr<Mirror>>(m, "Mirror")
+        .def(py::init<const Context&, const std::string&>());
 
-    py::class_<Context, std::unique_ptr<Context, py::nodelete>>(m, "Context")
-        .def(
-            py::init([]() { return std::unique_ptr<Context, py::nodelete>(&Context::instance()); }))
+    py::class_<Context, std::unique_ptr<Context>>(m, "Context")
+        .def(py::init([]{ return std::make_unique<Context>(); }))
         .def_readwrite("verbosity", &Context::verbosity)
         .def_readwrite("mirror_map", &Context::mirror_map);
 
     py::class_<Downloader>(m, "Downloader")
-        .def(py::init<>())
+        .def(py::init<const Context&>())
         .def("download", &Downloader::download)
         .def("add", &Downloader::add);
 }

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -5,21 +5,13 @@
 
 namespace powerloader
 {
-    Target::Target(const std::shared_ptr<DownloadTarget>& dl_target)
-        : state(DownloadState::kWAITING)
-        , target(dl_target)
-        , original_offset(-1)
-        , resume(dl_target->resume)
-    {
-    }
-
-    Target::Target(const std::shared_ptr<DownloadTarget>& dl_target,
-                   const std::vector<std::shared_ptr<Mirror>>& mirrors)
+    Target::Target(const Context& ctx, std::shared_ptr<DownloadTarget> dl_target, std::vector<std::shared_ptr<Mirror>> mirrors)
         : state(DownloadState::kWAITING)
         , target(dl_target)
         , original_offset(-1)
         , resume(dl_target->resume)
         , mirrors(mirrors)
+        , ctx(ctx)
     {
     }
 
@@ -59,7 +51,7 @@ namespace powerloader
             std::error_code ec;
             fs::rename(temp_file, target->fn, ec);
 
-            if (!ec && Context::instance().preserve_filetime)
+            if (!ec && ctx.preserve_filetime)
             {
                 auto remote_filetime = curl_handle->getinfo<curl_off_t>(CURLINFO_FILETIME_T);
                 if (!remote_filetime || remote_filetime.value() < 0)
@@ -484,7 +476,7 @@ namespace powerloader
 
     bool Target::check_checksums()
     {
-        if (!Context::instance().validate_checksum)
+        if (!ctx.validate_checksum)
         {
             return true;
         }

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -5,7 +5,9 @@
 
 namespace powerloader
 {
-    Target::Target(const Context& ctx, std::shared_ptr<DownloadTarget> dl_target, std::vector<std::shared_ptr<Mirror>> mirrors)
+    Target::Target(const Context& ctx,
+                   std::shared_ptr<DownloadTarget> dl_target,
+                   std::vector<std::shared_ptr<Mirror>> mirrors)
         : state(DownloadState::kWAITING)
         , target(dl_target)
         , original_offset(-1)

--- a/src/uploader/oci_upload.cpp
+++ b/src/uploader/oci_upload.cpp
@@ -83,7 +83,9 @@ namespace powerloader
     }
 
 
-    Response OCILayer::upload(const Context& ctx, const OCIMirror& mirror, const std::string& reference) const
+    Response OCILayer::upload(const Context& ctx,
+                              const OCIMirror& mirror,
+                              const std::string& reference) const
     {
         std::string preupload_url = mirror.get_preupload_url(reference);
         auto response = CURLHandle(ctx, preupload_url)
@@ -147,7 +149,7 @@ namespace powerloader
             = OCILayer::from_string("application/vnd.unknown.config.v1+json", std::string("{}"));
         OCILayer oci_layer_config = config.value_or(default_config);
 
-        CURLHandle auth_handle{ctx};
+        CURLHandle auth_handle{ ctx };
         if (mirror.need_auth() && mirror.prepare(reference, auth_handle))
         {
             auto auth_res = auth_handle.perform();

--- a/src/uploader/oci_upload.cpp
+++ b/src/uploader/oci_upload.cpp
@@ -83,10 +83,10 @@ namespace powerloader
     }
 
 
-    Response OCILayer::upload(const OCIMirror& mirror, const std::string& reference) const
+    Response OCILayer::upload(const Context& ctx, const OCIMirror& mirror, const std::string& reference) const
     {
         std::string preupload_url = mirror.get_preupload_url(reference);
-        auto response = CURLHandle(preupload_url)
+        auto response = CURLHandle(ctx, preupload_url)
                             .setopt(CURLOPT_CUSTOMREQUEST, "POST")
                             .add_headers(mirror.get_auth_headers(reference))
                             .perform();
@@ -101,7 +101,7 @@ namespace powerloader
         spdlog::info("Uploading digest {}", digest);
         spdlog::info("Upload url: {}", upload_url);
 
-        CURLHandle chandle(upload_url);
+        CURLHandle chandle(ctx, upload_url);
         // for uploading we always use application/octet-stream. The proper mimetypes
         // are defined in the manifest
         chandle.setopt(CURLOPT_UPLOAD, 1L)
@@ -135,7 +135,8 @@ namespace powerloader
         return json_layer;
     }
 
-    Response oci_upload(OCIMirror& mirror,
+    Response oci_upload(const Context& ctx,
+                        OCIMirror& mirror,
                         const std::string& reference,
                         const std::string& tag,
                         const std::vector<OCILayer>& layers,
@@ -146,7 +147,7 @@ namespace powerloader
             = OCILayer::from_string("application/vnd.unknown.config.v1+json", std::string("{}"));
         OCILayer oci_layer_config = config.value_or(default_config);
 
-        CURLHandle auth_handle;
+        CURLHandle auth_handle{ctx};
         if (mirror.need_auth() && mirror.prepare(reference, auth_handle))
         {
             auto auth_res = auth_handle.perform();
@@ -159,7 +160,7 @@ namespace powerloader
 
         for (auto& layer : layers)
         {
-            auto upload_res = layer.upload(mirror, reference);
+            auto upload_res = layer.upload(ctx, mirror, reference);
 
             if (!upload_res.ok())
                 return upload_res;
@@ -167,7 +168,7 @@ namespace powerloader
 
         // Upload the config, too
         {
-            auto upload_res = oci_layer_config.upload(mirror, reference);
+            auto upload_res = oci_layer_config.upload(ctx, mirror, reference);
             if (!upload_res.ok())
                 return upload_res;
         }
@@ -179,7 +180,7 @@ namespace powerloader
         spdlog::info("Manifest: {}", manifest);
         std::istringstream manifest_stream(manifest);
 
-        CURLHandle mhandle(manifest_url);
+        CURLHandle mhandle(ctx, manifest_url);
         mhandle.add_headers(mirror.get_auth_headers(reference))
             .add_header("Content-Type: application/vnd.oci.image.manifest.v1+json")
             .upload(manifest_stream);

--- a/src/uploader/s3_upload.cpp
+++ b/src/uploader/s3_upload.cpp
@@ -5,7 +5,10 @@
 
 namespace powerloader
 {
-    Response s3_upload(const Context& ctx, S3Mirror& mirror, const std::string& path, const fs::path& file)
+    Response s3_upload(const Context& ctx,
+                       S3Mirror& mirror,
+                       const std::string& path,
+                       const fs::path& file)
     {
         std::string digest = sha256sum(file);
         std::size_t fsize = fs::file_size(file);

--- a/src/uploader/s3_upload.cpp
+++ b/src/uploader/s3_upload.cpp
@@ -5,7 +5,7 @@
 
 namespace powerloader
 {
-    Response s3_upload(S3Mirror& mirror, const std::string& path, const fs::path& file)
+    Response s3_upload(const Context& ctx, S3Mirror& mirror, const std::string& path, const fs::path& file)
     {
         std::string digest = sha256sum(file);
         std::size_t fsize = fs::file_size(file);
@@ -18,7 +18,7 @@ namespace powerloader
         // this is enough to make a file completely public
         // request.headers["x-amz-acl"] = "public-read";
 
-        CURLHandle uploadrequest(uh.url());
+        CURLHandle uploadrequest(ctx, uh.url());
 
         std::ifstream ufile(file, std::ios::in | std::ios::binary);
 

--- a/test.py
+++ b/test.py
@@ -20,13 +20,13 @@ def progress(total, done):
 
 downTarg.progress_callback = progress
 
-dl = pypowerloader.Downloader()
-dl.add(downTarg)
-
 con = pypowerloader.Context()
 
+dl = pypowerloader.Downloader(con)
+dl.add(downTarg)
+
 # dl.download()
-mirror = pypowerloader.Mirror(baseurl)
+mirror = pypowerloader.Mirror(con, baseurl)
 
 print("mirror_map1: " + str(con.mirror_map))
 con.mirror_map = {"conda-forge": [mirror], "test": []}

--- a/test/test_s3.cpp
+++ b/test/test_s3.cpp
@@ -7,7 +7,8 @@ using namespace powerloader;
 TEST(s3, signdata)
 {
     // S3Mirror::SignData s3mirror_signdata("GET", "");
-    S3Mirror s3mirror_signdata("someurl");
+    Context ctx;
+    S3Mirror s3mirror_signdata(ctx, "someurl");
 
     const auto p0 = std::chrono::time_point<std::chrono::system_clock>{};
 


### PR DESCRIPTION
Now `powerloader::Context` can only have one instance live at any time, but it is not accessible through global access.
This helps for testing, avoiding static-init/delete-fiasco and constraining access to read-only of that instance when it make sense.

Note that right now this relies on https://github.com/mamba-org/powerloader/pull/95 being merged first which is why it have the same commits as a base. I'll set this PR as non-draft once that PR is merged.