### PR TITLE
Fix most warnings reported by msvc

### DIFF
--- a/include/powerloader/fileio.hpp
+++ b/include/powerloader/fileio.hpp
@@ -197,7 +197,7 @@ namespace powerloader
         {
             constexpr std::size_t bufsize = 2048;
             char buf[bufsize];
-            unsigned long size;
+            std::size_t size;
 
             this->seek(0, SEEK_SET);
             other.seek(0, SEEK_SET);

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -61,15 +61,15 @@ progress_callback(DownloadTarget* t, curl_off_t total, curl_off_t done)
         global_progress.total_done[t] = done;
     }
 
-    double total_done = 0;
+    std::uint64_t total_done = 0;
     for (auto& [k, v] : global_progress.total_done)
         total_done += v;
     total_done /= global_progress.total;
 
     std::size_t bar_width = 50;
     std::cout << "[";
-    int pos = bar_width * total_done;
-    for (int i = 0; i < bar_width; ++i)
+    std::size_t pos = bar_width * total_done;
+    for (std::size_t i = 0; i < bar_width; ++i)
     {
         if (i < pos)
             std::cout << "=";
@@ -78,7 +78,7 @@ progress_callback(DownloadTarget* t, curl_off_t total, curl_off_t done)
         else
             std::cout << " ";
     }
-    std::cout << "] " << int(total_done * 100.0) << " %\n";
+    std::cout << "] " << total_done * 100 << " %\n";
     std::cout.flush();
 
     return 0;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -410,7 +410,6 @@ namespace powerloader
     bool Downloader::prepare_next_transfer(bool* candidate_found)
     {
         Protocol protocol = Protocol::kOTHER;
-        bool ret;
 
         *candidate_found = false;
         auto next_target = select_next_target();
@@ -914,7 +913,8 @@ namespace powerloader
                     std::string complete_url_or_base_url = complete_url_in_path
                                                                ? current_target->target->path
                                                                : current_target->target->base_url;
-                    if (can_retry_download(current_target->retries, complete_url_or_base_url))
+                    if (can_retry_download(static_cast<int>(current_target->retries),
+                                           complete_url_or_base_url))
                     {
                         // Try another mirror or retry
                         if (!complete_url_or_base_url.empty())

--- a/src/mirrors/s3.cpp
+++ b/src/mirrors/s3.cpp
@@ -162,7 +162,7 @@ namespace powerloader
         unsigned int DateKeyLen;
         DateKey = HMAC(EVP_sha256(),
                        key1.c_str(),
-                       key1.size(),
+                       static_cast<int>(key1.size()),
                        reinterpret_cast<const unsigned char*>(yyyymmdd.c_str()),
                        yyyymmdd.size(),
                        NULL,

--- a/src/url.cpp
+++ b/src/url.cpp
@@ -77,7 +77,7 @@ namespace powerloader
         CURL* curl = curl_easy_init();
         if (curl)
         {
-            char* output = curl_easy_escape(curl, url.c_str(), url.size());
+            char* output = curl_easy_escape(curl, url.c_str(), static_cast<int>(url.size()));
             if (output)
             {
                 std::string result(output);
@@ -95,7 +95,8 @@ namespace powerloader
         if (curl)
         {
             int out_length;
-            char* output = curl_easy_unescape(curl, url.c_str(), url.size(), &out_length);
+            char* output
+                = curl_easy_unescape(curl, url.c_str(), static_cast<int>(url.size()), &out_length);
             if (output)
             {
                 std::string result(output, out_length);

--- a/src/zck.cpp
+++ b/src/zck.cpp
@@ -595,7 +595,7 @@ namespace powerloader
         size_t total = 0;
         while (true)
         {
-            off_t read = zck_read(zck, buf.data(), BUF_SIZE);
+            size_t read = zck_read(zck, buf.data(), BUF_SIZE);
             if (read < 0)
             {
                 spdlog::error("Error reading file {}: {}", source.string(), zck_get_error(zck));

--- a/src/zck.hpp
+++ b/src/zck.hpp
@@ -41,10 +41,10 @@ namespace powerloader
         fs::path zck_cache_file;
 
         // Total to download in zchunk file
-        double total_to_download;
+        std::uint64_t total_to_download;
 
         // Amount already downloaded in zchunk file
-        double downloaded;
+        std::uint64_t downloaded;
     };
 
     zck_hash zck_hash_from_checksum(ChecksumType checksum_type);


### PR DESCRIPTION
Note that currently we build with low warning level, so we don't get much of them.

~~`lseek` is deprecated and replaced by `_lseek`.~~

There are still security issues with some functions, not sure how if fixing them is portable.