### PR TITLE
Shared library support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        shared-library: [ON, OFF]
 
     name: test
     steps:
@@ -37,7 +38,8 @@ jobs:
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
             -DWITH_ZCHUNK=$USE_ZCHUNK \
-            -DENABLE_TESTS=ON
+            -DENABLE_TESTS=ON \
+            -DBUILD_SHARED_LIBS=${{matrix.shared-library}}
           ninja
       - name: run powerloader tests
         if: runner.os != 'Windows'
@@ -62,6 +64,7 @@ jobs:
           cmake .. -DCMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library ^
                    -DENABLE_TESTS=ON ^
                    -DWITH_ZCHUNK=OFF ^
+                   -DBUILD_SHARED_LIBS=${{matrix.shared-library}} ^
                    -G "Ninja"
           ninja
           ninja test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,19 @@ else()
     message(ERROR "libpowerloader used as neither shared or static library: not supported")
 endif()
 
+# Custom build flags
+if(MSVC)
+    target_compile_options(libpowerloader
+        PUBLIC
+            /wd4275 # Disable warning C4275: We know that we use templates instances in our symbol exports.
+            /wd4251 # Disable warning C4251: We know that we use templates instances in our symbol exports.
+#         PRIVATE
+#             /W4 # Recommended warning level 4
+    )
+else()
+    # TODO: enable tons of warnings to help with security and correctness
+endif()
+
 
 add_executable(powerloader src/cli/main.cpp)
 set_property(TARGET powerloader PROPERTY CXX_STANDARD 17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set(LIBPOWERLOADER_HEADERS
 
 option(WITH_ZCHUNK "Enable zchunk" ON)
 option(DEV "Enable dev" OFF)
+option(BUILD_SHARED_LIBS "Build as shared libraries" ON)
 
 if (WITH_ZCHUNK)
     list(APPEND LIBPOWERLOADER_SRCS src/zck.cpp src/zck.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif()
 find_package(spdlog REQUIRED)
 if (MSVC)
     set(SPDLOG_TARGET spdlog::spdlog_header_only)
+    set(WINSOCK_LIBS wsock32 ws2_32)
 else()
     set(SPDLOG_TARGET spdlog::spdlog)
 endif()
@@ -110,9 +111,9 @@ target_link_libraries(libpowerloader
                         ${SPDLOG_TARGET}
                         ${ZCK_LIBRARY}
                         ${OPENSSL_LIBRARIES}
-                        yaml-cpp
+                        ${WINSOCK_LIBS}
                     )
-target_link_libraries(powerloader libpowerloader CLI11::CLI11)
+target_link_libraries(powerloader libpowerloader CLI11::CLI11 yaml-cpp)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(OpenSSL REQUIRED)
 find_package(CLI11 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(tl-expected REQUIRED)
+find_package(spdlog REQUIRED)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -44,14 +45,9 @@ set(LIBPOWERLOADER_HEADERS
     include/powerloader/mirrors/s3.hpp
 )
 
-
-
-add_executable(powerloader src/cli/main.cpp)
-
-set_property(TARGET powerloader PROPERTY CXX_STANDARD 17)
-
 option(WITH_ZCHUNK "Enable zchunk" ON)
 option(DEV "Enable dev" OFF)
+
 
 if (WITH_ZCHUNK)
     list(APPEND LIBPOWERLOADER_SRCS src/zck.cpp src/zck.hpp)
@@ -73,12 +69,32 @@ set_target_properties(libpowerloader
     PROPERTIES PREFIX ""
 )
 
+if (MSVC)
+    set(SPDLOG_TARGET spdlog::spdlog_header_only)
+    set(WINSOCK_LIBS wsock32 ws2_32)
+else()
+    set(SPDLOG_TARGET spdlog::spdlog)
+endif()
+target_link_libraries(libpowerloader
+    INTERFACE
+        tl::expected
+    PRIVATE
+        ${CURL_LIBRARIES}
+        ${SPDLOG_TARGET}
+        ${ZCK_LIBRARY}
+        ${OPENSSL_LIBRARIES}
+        ${WINSOCK_LIBS}
+)
+
+
+add_executable(powerloader src/cli/main.cpp)
+set_property(TARGET powerloader PROPERTY CXX_STANDARD 17)
 target_include_directories(powerloader PUBLIC
     include
     ${CURL_INCLUDE_DIRS}
     ${ZCK_INCLUDE_DIRS}
 )
-
+target_link_libraries(powerloader libpowerloader CLI11::CLI11 yaml-cpp)
 set_target_properties(powerloader PROPERTIES PUBLIC_HEADER "${LIBPOWERLOADER_HEADERS}")
 
 if (DEV)
@@ -96,25 +112,6 @@ if (WITH_ZCHUNK)
         target_compile_definitions(libpowerloader PUBLIC /wd4996)
     endif()
 endif()
-
-find_package(spdlog REQUIRED)
-if (MSVC)
-    set(SPDLOG_TARGET spdlog::spdlog_header_only)
-    set(WINSOCK_LIBS wsock32 ws2_32)
-else()
-    set(SPDLOG_TARGET spdlog::spdlog)
-endif()
-target_link_libraries(libpowerloader
-                    INTERFACE
-                        tl::expected
-                    PRIVATE
-                        ${CURL_LIBRARIES}
-                        ${SPDLOG_TARGET}
-                        ${ZCK_LIBRARY}
-                        ${OPENSSL_LIBRARIES}
-                        ${WINSOCK_LIBS}
-                    )
-target_link_libraries(powerloader libpowerloader CLI11::CLI11 yaml-cpp)
 
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(LIBPOWERLOADER_SRCS
 )
 
 set(LIBPOWERLOADER_HEADERS
+    include/powerloader/export.hpp
     include/powerloader/context.hpp
     include/powerloader/curl.hpp
     include/powerloader/download_target.hpp
@@ -39,6 +40,8 @@ set(LIBPOWERLOADER_HEADERS
     include/powerloader/url.hpp
     include/powerloader/target.hpp
     include/powerloader/utils.hpp
+    include/powerloader/mirrors/oci.hpp
+    include/powerloader/mirrors/s3.hpp
 )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ set(LIBPOWERLOADER_HEADERS
 option(WITH_ZCHUNK "Enable zchunk" ON)
 option(DEV "Enable dev" OFF)
 
-
 if (WITH_ZCHUNK)
     list(APPEND LIBPOWERLOADER_SRCS src/zck.cpp src/zck.hpp)
     find_library(ZCK_LIBRARY zck REQUIRED)
@@ -85,6 +84,17 @@ target_link_libraries(libpowerloader
         ${OPENSSL_LIBRARIES}
         ${WINSOCK_LIBS}
 )
+
+get_target_property(library_type libpowerloader TYPE)
+if(library_type STREQUAL SHARED_LIBRARY)
+    # As a shared library: build exports symbols, usage will import.
+    target_compile_definitions(libpowerloader PRIVATE POWERLOADER_EXPORTS)
+elseif(library_type STREQUAL STATIC_LIBRARY)
+    # As a static library: no symbol import/export from any side.
+    target_compile_definitions(libpowerloader PUBLIC POWERLOADER_STATIC)
+else()
+    message(ERROR "libpowerloader used as neither shared or static library: not supported")
+endif()
 
 
 add_executable(powerloader src/cli/main.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(WITH_ZCHUNK "Enable zchunk" ON)
 option(DEV "Enable dev" OFF)
 
 if (WITH_ZCHUNK)
-    list(APPEND LIBPOWERLOADER_SRCS src/zck.cpp)
+    list(APPEND LIBPOWERLOADER_SRCS src/zck.cpp src/zck.hpp)
     find_library(ZCK_LIBRARY zck REQUIRED)
     find_file(ZCK_H_FILE NAMES zck.h REQUIRED)
     message("Found file: ${ZCK_H_FILE}")
@@ -67,6 +67,7 @@ endif()
 
 add_library(libpowerloader
     ${LIBPOWERLOADER_SRCS}
+    ${LIBPOWERLOADER_HEADERS} # Makes headers visible in IDEs
 )
 set_target_properties(libpowerloader
     PROPERTIES PREFIX ""

--- a/include/powerloader/context.hpp
+++ b/include/powerloader/context.hpp
@@ -8,13 +8,15 @@
 #include <filesystem>
 #include <spdlog/spdlog.h>
 
+#include <powerloader/export.hpp>
+
 namespace powerloader
 {
     namespace fs = std::filesystem;
 
     struct Mirror;
 
-    class Context
+    class POWERLOADER_API Context
     {
     public:
         bool offline = false;

--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -12,6 +12,7 @@
 #include <nlohmann/json.hpp>
 #include <tl/expected.hpp>
 
+#include <powerloader/export.hpp>
 #include <powerloader/utils.hpp>
 #include <powerloader/enums.hpp>
 
@@ -24,7 +25,7 @@ namespace powerloader
 #include <curl/curl.h>
     }
 
-    class curl_error : public std::runtime_error
+    class POWERLOADER_API curl_error : public std::runtime_error
     {
     public:
         curl_error(const std::string& what = "download error", bool serious = false);
@@ -34,7 +35,7 @@ namespace powerloader
         bool m_serious;
     };
 
-    struct Response
+    struct POWERLOADER_API Response
     {
         std::map<std::string, std::string> header;
         mutable std::stringstream content;
@@ -49,9 +50,9 @@ namespace powerloader
     };
 
     // TODO: rename this, try to not expose it
-    CURL* get_handle(const Context& ctx);
+    POWERLOADER_API  CURL* get_handle(const Context& ctx);
 
-    class CURLHandle
+    class POWERLOADER_API  CURLHandle
     {
     public:
         using end_callback_type = std::function<CbReturnCode(const Response&)>;

--- a/include/powerloader/download_target.hpp
+++ b/include/powerloader/download_target.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <powerloader/export.hpp>
 #include <powerloader/enums.hpp>
 #include <powerloader/url.hpp>
 #include <powerloader/mirror.hpp>
@@ -14,7 +15,7 @@ namespace powerloader
 
     class zck_target;
 
-    class DownloadTarget
+    class POWERLOADER_API DownloadTarget
     {
     public:
         /** Called when a transfer is done (use transfer status to check

--- a/include/powerloader/downloader.hpp
+++ b/include/powerloader/downloader.hpp
@@ -19,7 +19,7 @@ extern "C"
 #include <fcntl.h>
 }
 
-
+#include <powerloader/export.hpp>
 #include <powerloader/context.hpp>
 #include <powerloader/curl.hpp>
 #include <powerloader/download_target.hpp>
@@ -35,7 +35,7 @@ namespace powerloader
 
     class Context;
 
-    class Downloader
+    class POWERLOADER_API Downloader
     {
     public:
         explicit Downloader(const Context& ctx);

--- a/include/powerloader/errors.hpp
+++ b/include/powerloader/errors.hpp
@@ -93,16 +93,17 @@ namespace powerloader
         ErrorCode code;
         std::string reason;
 
-        inline bool is_serious()
+        bool is_serious() noexcept
         {
             return (level == ErrorLevel::SERIOUS || level == ErrorLevel::FATAL);
         }
-        inline bool is_fatal()
+
+        bool is_fatal() noexcept
         {
             return level == ErrorLevel::FATAL;
         }
 
-        inline void log()
+        void log()
         {
             switch (level)
             {

--- a/include/powerloader/export.hpp
+++ b/include/powerloader/export.hpp
@@ -1,0 +1,42 @@
+
+#ifndef POWERLOADER_API_HPP
+#define POWERLOADER_API_HPP
+
+#ifdef POWERLOADER_STATIC_DEFINE
+#  define POWERLOADER_API
+#  define POWERLOADER_NO_EXPORT
+#else
+#  ifndef POWERLOADER_API
+#    ifdef libpowerloader_EXPORTS
+        /* We are building this library */
+#      define POWERLOADER_API __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define POWERLOADER_API __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef POWERLOADER_NO_EXPORT
+#    define POWERLOADER_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef POWERLOADER_DEPRECATED
+#  define POWERLOADER_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef POWERLOADER_DEPRECATED_EXPORT
+#  define POWERLOADER_DEPRECATED_EXPORT POWERLOADER_API POWERLOADER_DEPRECATED
+#endif
+
+#ifndef POWERLOADER_DEPRECATED_NO_EXPORT
+#  define POWERLOADER_DEPRECATED_NO_EXPORT POWERLOADER_NO_EXPORT POWERLOADER_DEPRECATED
+#endif
+
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef POWERLOADER_NO_DEPRECATED
+#    define POWERLOADER_NO_DEPRECATED
+#  endif
+#endif
+
+#endif /* POWERLOADER_API_HPP */

--- a/include/powerloader/export.hpp
+++ b/include/powerloader/export.hpp
@@ -2,41 +2,19 @@
 #ifndef POWERLOADER_API_HPP
 #define POWERLOADER_API_HPP
 
-#ifdef POWERLOADER_STATIC_DEFINE
+
+#ifdef POWERLOADER_STATIC
+// As a static library: no symbol import/export.
 #  define POWERLOADER_API
-#  define POWERLOADER_NO_EXPORT
 #else
-#  ifndef POWERLOADER_API
-#    ifdef libpowerloader_EXPORTS
-        /* We are building this library */
-#      define POWERLOADER_API __declspec(dllexport)
-#    else
-        /* We are using this library */
-#      define POWERLOADER_API __declspec(dllimport)
-#    endif
-#  endif
-
-#  ifndef POWERLOADER_NO_EXPORT
-#    define POWERLOADER_NO_EXPORT 
+ // As a shared library: export symbols on build, import symbols on use.
+#  ifdef POWERLOADER_EXPORTS
+     // We are building this library
+#    define POWERLOADER_API __declspec(dllexport)
+#  else
+     // We are using this library
+#    define POWERLOADER_API __declspec(dllimport)
 #  endif
 #endif
 
-#ifndef POWERLOADER_DEPRECATED
-#  define POWERLOADER_DEPRECATED __declspec(deprecated)
 #endif
-
-#ifndef POWERLOADER_DEPRECATED_EXPORT
-#  define POWERLOADER_DEPRECATED_EXPORT POWERLOADER_API POWERLOADER_DEPRECATED
-#endif
-
-#ifndef POWERLOADER_DEPRECATED_NO_EXPORT
-#  define POWERLOADER_DEPRECATED_NO_EXPORT POWERLOADER_NO_EXPORT POWERLOADER_DEPRECATED
-#endif
-
-#if 0 /* DEFINE_NO_DEPRECATED */
-#  ifndef POWERLOADER_NO_DEPRECATED
-#    define POWERLOADER_NO_DEPRECATED
-#  endif
-#endif
-
-#endif /* POWERLOADER_API_HPP */

--- a/include/powerloader/fastest_mirror.hpp
+++ b/include/powerloader/fastest_mirror.hpp
@@ -4,11 +4,13 @@
 #include <string>
 #include <vector>
 
+#include <powerloader/export.hpp>
+
 namespace powerloader
 {
     class Context;
 
-    void fastest_mirror(const Context& ctx, const std::vector<std::string>& urls);
+    POWERLOADER_API void fastest_mirror(const Context& ctx, const std::vector<std::string>& urls);
 }
 
 #endif

--- a/include/powerloader/mirror.hpp
+++ b/include/powerloader/mirror.hpp
@@ -7,13 +7,14 @@
 #include <sstream>
 #include <string>
 #include <spdlog/spdlog.h>
+#include <nlohmann/json.hpp>
 
+#include <powerloader/export.hpp>
 #include <powerloader/context.hpp>
 #include <powerloader/curl.hpp>
 #include <powerloader/enums.hpp>
 #include <powerloader/utils.hpp>
 
-#include "nlohmann/json.hpp"
 
 namespace powerloader
 {
@@ -31,7 +32,7 @@ namespace powerloader
     };
 
     // mirrors should be dict -> urls mapping
-    struct Mirror
+    struct POWERLOADER_API Mirror
     {
         Mirror(const Context& ctx, const std::string& url);
         virtual ~Mirror() = default;

--- a/include/powerloader/mirrors/oci.hpp
+++ b/include/powerloader/mirrors/oci.hpp
@@ -2,13 +2,14 @@
 #define POWERLOADER_OCI_HPP
 
 #include <optional>
-
 #include <spdlog/fmt/fmt.h>
+
+#include <powerloader/export.hpp>
 #include <powerloader/mirror.hpp>
 
 namespace powerloader
 {
-    class OCIMirror : public Mirror
+    class POWERLOADER_API OCIMirror : public Mirror
     {
     public:
         struct AuthCallbackData
@@ -63,7 +64,7 @@ namespace powerloader
         split_function_type m_split_func;
     };
 
-    struct OCILayer
+    struct POWERLOADER_API OCILayer
     {
         std::string mime_type;
 
@@ -100,6 +101,7 @@ namespace powerloader
                  const std::optional<nlohmann::json>& annotations = std::nullopt);
     };
 
+    POWERLOADER_API
     Response oci_upload(const Context& ctx,
                         OCIMirror& mirror,
                         const std::string& reference,

--- a/include/powerloader/mirrors/s3.hpp
+++ b/include/powerloader/mirrors/s3.hpp
@@ -3,13 +3,14 @@
 
 #include <spdlog/fmt/fmt.h>
 
+#include <powerloader/export.hpp>
 #include <powerloader/mirror.hpp>
 #include <powerloader/target.hpp>
 
 namespace powerloader
 {
 
-    struct S3CanonicalRequest
+    struct POWERLOADER_API S3CanonicalRequest
     {
         std::string http_verb;
         std::string resource;
@@ -32,7 +33,7 @@ namespace powerloader
     };
 
     // https://gist.github.com/mmaday/c82743b1683ce4d27bfa6615b3ba2332
-    class S3Mirror : public Mirror
+    class POWERLOADER_API S3Mirror : public Mirror
     {
     public:
         S3Mirror(const Context& ctx,
@@ -64,6 +65,7 @@ namespace powerloader
         std::string region = "eu-central-1";
     };
 
+    POWERLOADER_API
     Response s3_upload(const Context& ctx,
                        S3Mirror& mirror,
                        const std::string& path,

--- a/include/powerloader/target.hpp
+++ b/include/powerloader/target.hpp
@@ -2,10 +2,11 @@
 #define POWERLOADER_TARGET_HPP
 
 #include <filesystem>
-#include <spdlog/spdlog.h>
 #include <fstream>
 #include <set>
+#include <spdlog/spdlog.h>
 
+#include <powerloader/export.hpp>
 #include <powerloader/curl.hpp>
 #include <powerloader/download_target.hpp>
 #include <powerloader/enums.hpp>
@@ -16,7 +17,7 @@ namespace powerloader
 {
     namespace fs = std::filesystem;
 
-    class Target
+    class POWERLOADER_API Target
     {
     public:
         /** Header callback for CURL handles.

--- a/include/powerloader/url.hpp
+++ b/include/powerloader/url.hpp
@@ -17,6 +17,8 @@ extern "C"
 #include <string>
 #include <vector>
 
+#include <powerloader/export.hpp>
+
 // typedef enum {
 //   CURLUE_OK,
 //   CURLUE_BAD_HANDLE,          /* 1 */
@@ -40,23 +42,23 @@ extern "C"
 
 namespace powerloader
 {
-    bool has_scheme(const std::string& url);
+    POWERLOADER_API bool has_scheme(const std::string& url);
 
-    bool compare_cleaned_url(const std::string& url1, const std::string& url2);
+    POWERLOADER_API bool compare_cleaned_url(const std::string& url1, const std::string& url2);
 
-    bool is_path(const std::string& input);
-    std::string path_to_url(const std::string& path);
+    POWERLOADER_API bool is_path(const std::string& input);
+    POWERLOADER_API std::string path_to_url(const std::string& path);
 
     template <class S, class... Args>
     std::string join_url(const S& s, const Args&... args);
 
-    std::string unc_url(const std::string& url);
-    std::string encode_url(const std::string& url);
-    std::string decode_url(const std::string& url);
+    POWERLOADER_API std::string unc_url(const std::string& url);
+    POWERLOADER_API std::string encode_url(const std::string& url);
+    POWERLOADER_API std::string decode_url(const std::string& url);
     // Only returns a cache name without extension
-    std::string cache_name_from_url(const std::string& url);
+    POWERLOADER_API std::string cache_name_from_url(const std::string& url);
 
-    class URLHandler
+    class POWERLOADER_API URLHandler
     {
     public:
         URLHandler(const std::string& url = "");

--- a/include/powerloader/utils.hpp
+++ b/include/powerloader/utils.hpp
@@ -12,13 +12,15 @@
 #include <cctype>
 #include <vector>
 
+#include <powerloader/export.hpp>
+
 namespace powerloader
 {
     namespace fs = std::filesystem;
 
-    bool is_sig_interrupted();
-    bool starts_with(const std::string_view& str, const std::string_view& prefix);
-    bool ends_with(const std::string_view& str, const std::string_view& suffix);
+    POWERLOADER_API bool is_sig_interrupted();
+    POWERLOADER_API bool starts_with(const std::string_view& str, const std::string_view& prefix);
+    POWERLOADER_API bool ends_with(const std::string_view& str, const std::string_view& suffix);
 
     template <class B>
     inline std::vector<char> hex_to_bytes(const B& buffer, std::size_t size) noexcept
@@ -60,9 +62,9 @@ namespace powerloader
         return hex_string(buffer, buffer.size());
     }
 
-    std::string sha256(const std::string& str) noexcept;
+    POWERLOADER_API std::string sha256(const std::string& str) noexcept;
 
-    class download_error : public std::runtime_error
+    class POWERLOADER_API download_error : public std::runtime_error
     {
     public:
         download_error(const std::string& what = "download error", bool serious = false)
@@ -82,22 +84,26 @@ namespace powerloader
         }
     };
 
-    std::string string_transform(const std::string_view& input, int (*functor)(int));
-    std::string to_upper(const std::string_view& input);
-    std::string to_lower(const std::string_view& input);
-    bool contains(const std::string_view& str, const std::string_view& sub_str);
+    POWERLOADER_API std::string string_transform(const std::string_view& input,
+                                                 int (*functor)(int));
+    POWERLOADER_API std::string to_upper(const std::string_view& input);
+    POWERLOADER_API std::string to_lower(const std::string_view& input);
+    POWERLOADER_API bool contains(const std::string_view& str, const std::string_view& sub_str);
 
-    std::string sha256sum(const fs::path& path);
-    std::string md5sum(const fs::path& path);
+    POWERLOADER_API std::string sha256sum(const fs::path& path);
+    POWERLOADER_API std::string md5sum(const fs::path& path);
 
-    std::pair<std::string, std::string> parse_header(const std::string_view& header);
-    std::string get_env(const char* var);
-    std::string get_env(const char* var, const std::string& default_value);
+    POWERLOADER_API std::pair<std::string, std::string> parse_header(
+        const std::string_view& header);
+    POWERLOADER_API std::string get_env(const char* var);
+    POWERLOADER_API std::string get_env(const char* var, const std::string& default_value);
 
+    POWERLOADER_API
     std::vector<std::string> split(const std::string_view& input,
                                    const std::string_view& sep,
                                    std::size_t max_split = SIZE_MAX);
 
+    POWERLOADER_API
     std::vector<std::string> rsplit(const std::string_view& input,
                                     const std::string_view& sep,
                                     std::size_t max_split);
@@ -114,8 +120,10 @@ namespace powerloader
         }
     }
 
+    POWERLOADER_API
     void replace_all(std::string& data, const std::string& search, const std::string& replace);
 
+    POWERLOADER_API
     void replace_all(std::wstring& data, const std::wstring& search, const std::wstring& replace);
 }
 

--- a/src/zck.hpp
+++ b/src/zck.hpp
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <powerloader/export.hpp>
 #include <powerloader/enums.hpp>
 #include <powerloader/target.hpp>
 
@@ -47,44 +48,48 @@ namespace powerloader
         std::uint64_t downloaded;
     };
 
-    zck_hash zck_hash_from_checksum(ChecksumType checksum_type);
-    ChecksumType checksum_type_from_zck_hash(zck_hash hash_type);
+    POWERLOADER_API zck_hash zck_hash_from_checksum(ChecksumType checksum_type);
+    POWERLOADER_API ChecksumType checksum_type_from_zck_hash(zck_hash hash_type);
 
+    POWERLOADER_API 
     zckCtx* init_zck_read(const std::unique_ptr<Checksum>& chksum,
                           ptrdiff_t zck_header_size,
                           int fd);
 
+    POWERLOADER_API 
     zckCtx* zck_init_read_base(const std::unique_ptr<Checksum>& chksum,
                                std::ptrdiff_t zck_header_size,
                                int fd);
 
+    POWERLOADER_API 
     bool zck_valid_header_base(const std::unique_ptr<Checksum>& chksum,
                                std::ptrdiff_t zck_header_size,
                                int fd);
 
-    zckCtx* zck_init_read(const std::shared_ptr<DownloadTarget>& target, int fd);
-    zckCtx* zck_init_read(Target* target);
+    POWERLOADER_API zckCtx* zck_init_read(const std::shared_ptr<DownloadTarget>& target, int fd);
+    POWERLOADER_API zckCtx* zck_init_read(Target* target);
 
-    bool zck_valid_header(const std::shared_ptr<DownloadTarget>& target, int fd);
-    bool zck_valid_header(Target* target);
+    POWERLOADER_API bool zck_valid_header(const std::shared_ptr<DownloadTarget>& target, int fd);
+    POWERLOADER_API bool zck_valid_header(Target* target);
 
-    bool zck_clear_header(Target* target);
-    bool zck_read_lead(Target* target);
-    std::vector<fs::path> get_recursive_files(fs::path dir, const std::string& suffix);
+    POWERLOADER_API bool zck_clear_header(Target* target);
+    POWERLOADER_API bool zck_read_lead(Target* target);
+    POWERLOADER_API std::vector<fs::path> get_recursive_files(fs::path dir,
+                                                              const std::string& suffix);
 
     // TODO replace...
-    int lr_copy_content(int source, int dest);
+    POWERLOADER_API int lr_copy_content(int source, int dest);
 
-    bool find_local_zck_header(Target* target);
+    POWERLOADER_API bool find_local_zck_header(Target* target);
 
-    bool prep_zck_header(Target* target);
+    POWERLOADER_API bool prep_zck_header(Target* target);
 
-    bool find_local_zck_chunks(Target* target);
+    POWERLOADER_API bool find_local_zck_chunks(Target* target);
 
-    bool prepare_zck_body(Target* target);
-    bool check_zck(Target* target);
+    POWERLOADER_API bool prepare_zck_body(Target* target);
+    POWERLOADER_API bool check_zck(Target* target);
 
-    bool zck_extract(const fs::path& source, const fs::path& dst, bool validate);
+    POWERLOADER_API bool zck_extract(const fs::path& source, const fs::path& dst, bool validate);
 }
 
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,17 @@ set(TEST_SRCS
 
 add_executable(test_powerloader ${TEST_SRCS})
 
-target_link_libraries(test_powerloader PRIVATE GTest::GTest GTest::Main libpowerloader)
+target_link_libraries(test_powerloader
+    PRIVATE
+        libpowerloader
+        GTest::GTest
+        GTest::Main
+)
 set_property(TARGET test_powerloader PROPERTY CXX_STANDARD 17)
 
-add_custom_target(test COMMAND test_powerloader DEPENDS test_powerloader)
+add_custom_target(test
+    COMMAND test_powerloader
+    DEPENDS test_powerloader
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:libpowerloader>
+)
+


### PR DESCRIPTION
If I did it right:

- CI should build and test both static and shared versions of `libpowerloader` (might be broken right now, will need to check the cI);
- Use `POWERLOADER_API` in `libpowerloader` headers to mark functions (and functions in classes) that needs to be exported symbols;
- Makes shared library build the default if `BUILD_SHARED_LIBS` is not specified;
