### PR TITLE
Cache handling

### DIFF
--- a/include/powerloader/download_target.hpp
+++ b/include/powerloader/download_target.hpp
@@ -6,6 +6,7 @@
 #include <powerloader/export.hpp>
 #include <powerloader/enums.hpp>
 #include <powerloader/url.hpp>
+#include <powerloader/curl.hpp>
 #include <powerloader/mirror.hpp>
 #include <powerloader/fileio.hpp>
 #include <powerloader/errors.hpp>
@@ -14,6 +15,13 @@ namespace powerloader
 {
 
     class zck_target;
+
+    struct POWERLOADER_API CacheControl
+    {
+        std::string etag;
+        std::string cache_control;
+        std::string last_modified;
+    };
 
     class POWERLOADER_API DownloadTarget
     {
@@ -30,6 +38,9 @@ namespace powerloader
 
         DownloadTarget(const std::string& path, const std::string& base_url, const fs::path& fn);
         ~DownloadTarget();
+
+        void set_cache_options(const CacheControl& cache_control);
+        void add_handle_options(CURLHandle& handle);
 
         DownloadTarget(const DownloadTarget&) = delete;
         DownloadTarget& operator=(const DownloadTarget&) = delete;
@@ -71,6 +82,9 @@ namespace powerloader
         // We cannot use a unique_ptr here because of the python bindings
         // which needs the sizeof zck_target
         zck_target* p_zck;
+
+    private:
+        CacheControl m_cache_control;
     };
 
 }

--- a/src/download_target.cpp
+++ b/src/download_target.cpp
@@ -111,4 +111,24 @@ namespace powerloader
     {
         error = std::make_unique<DownloaderError>(err);
     }
+
+    void DownloadTarget::set_cache_options(const CacheControl& cache_control)
+    {
+        m_cache_control = cache_control;
+    }
+
+    void DownloadTarget::add_handle_options(CURLHandle& handle)
+    {
+        auto to_header = [](const std::string& key, const std::string& value)
+        { return std::string(key + ": " + value); };
+
+        if (m_cache_control.etag.size())
+        {
+            handle.add_header(to_header("If-None-Match", m_cache_control.etag));
+        }
+        if (m_cache_control.last_modified.size())
+        {
+            handle.add_header(to_header("If-Modified-Since", m_cache_control.last_modified));
+        }
+    }
 }

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -187,7 +187,7 @@ namespace powerloader
             curl_easy_getinfo(msg->easy_handle, CURLINFO_PRIMARY_IP, &effective_ip);
 
             // Check HTTP(S) code / or FTP
-            if (code / 100 != 2)
+            if (code / 100 != 2 && code != 304)
             {
                 return tl::unexpected(DownloaderError{
                     ErrorLevel::INFO,
@@ -593,6 +593,10 @@ namespace powerloader
             // Add headers that tell proxy to serve us fresh data
             h.add_header("Cache-Control: no-cache");
             h.add_header("Pragma: no-cache");
+        }
+        else
+        {
+            target->target->add_handle_options(h);
         }
 
         // Add the new handle to the curl multi handle


### PR DESCRIPTION
This allows setting the `If-None-Match` and `If-Modified-Since` headers that are used to identify if a file has not been updated on the server (server should reply with `304` in that case).