### PR TITLE
Moved `DownloadTarget` data members in private + refactor

### DIFF
--- a/include/powerloader/download_target.hpp
+++ b/include/powerloader/download_target.hpp
@@ -14,7 +14,7 @@
 namespace powerloader
 {
 
-    class zck_target;
+    struct zck_target;
 
     struct POWERLOADER_API CacheControl
     {
@@ -36,16 +36,18 @@ namespace powerloader
         using end_callback_t = std::function<CbReturnCode(TransferStatus, const Response&)>;
         using progress_callback_t = std::function<int(curl_off_t, curl_off_t)>;
 
-        DownloadTarget(const std::string& path, const std::string& base_url, const fs::path& fn);
+        DownloadTarget(const std::string& path,
+                       const std::string& base_url,
+                       const fs::path& filename);
         ~DownloadTarget();
-
-        void set_cache_options(const CacheControl& cache_control);
-        void add_handle_options(CURLHandle& handle);
 
         DownloadTarget(const DownloadTarget&) = delete;
         DownloadTarget& operator=(const DownloadTarget&) = delete;
         DownloadTarget(DownloadTarget&&) = delete;
         DownloadTarget& operator=(DownloadTarget&&) = delete;
+
+        void set_cache_options(const CacheControl& cache_control);
+        void add_handle_options(CURLHandle& handle);
 
         bool has_complete_url() const;
         bool validate_checksum(const fs::path& path);
@@ -53,37 +55,205 @@ namespace powerloader
 
         void set_error(const DownloaderError& err);
 
+        bool resume() const noexcept
+        {
+            return m_resume;
+        }
 
-        bool is_zchunk = false;
-        bool resume = true;
-        bool no_cache = false;
+        void set_resume(bool new_value) noexcept
+        {
+            m_resume = new_value;
+        }
 
-        std::string complete_url;
-        std::string path, base_url;
-        std::unique_ptr<FileIO> outfile;
+        bool no_cache() const noexcept
+        {
+            return m_no_cache;
+        }
 
-        fs::path fn;
+        const std::string& base_url() const noexcept
+        {
+            return m_base_url;
+        }
 
-        std::size_t byterange_start = 0, byterange_end = 0;
-        std::string range;
-        std::ptrdiff_t expected_size = 0;
-        std::ptrdiff_t orig_size = 0;
+        void clear_base_url()
+        {
+            m_base_url.clear();
+        }
 
-        progress_callback_t progress_callback;
-        end_callback_t end_callback;
 
-        // these are available checksums for the entire file
-        std::vector<Checksum> checksums;
+        const std::string& complete_url() const noexcept
+        {
+            return m_complete_url;
+        }
 
-        std::shared_ptr<Mirror> used_mirror;
-        std::string effective_url;
-        std::unique_ptr<DownloaderError> error;
+        const std::string& path() const noexcept
+        {
+            return m_path;
+        }
 
-        // We cannot use a unique_ptr here because of the python bindings
-        // which needs the sizeof zck_target
-        zck_target* p_zck;
+        const std::filesystem::path& filename() const noexcept
+        {
+            return m_filename;
+        }
+
+        std::size_t byterange_start() const noexcept
+        {
+            return m_byterange_start;
+        }
+
+        std::size_t byterange_end() const noexcept
+        {
+            return m_byterange_end;
+        }
+
+        std::ptrdiff_t expected_size() const noexcept
+        {
+            return m_expected_size;
+        }
+
+        // TOOD: check SOC (why is this modifed outside)
+        void set_expected_size(std::ptrdiff_t value)
+        {
+            // TODO: add checks?
+            m_expected_size = value;
+        }
+
+        std::ptrdiff_t orig_size() const noexcept
+        {
+            return m_orig_size;
+        }
+
+        const std::string& range() const noexcept
+        {
+            return m_range;
+        }
+
+        // TODO: fix SOC with zchunk's code modifying this outside
+        std::string& range() noexcept
+        {
+            return m_range;
+        }
+
+        bool is_zchunck() const noexcept
+        {
+            return m_is_zchunk;
+        }
+
+        const zck_target& zck() const
+        {
+            if (!is_zchunck())  // TODO: REVIEW: should this be an assert?
+                throw std::invalid_argument("attempted to access zchunk data but there is none");
+            return *m_p_zck;
+        }
+
+        // TODO: ownership/access issue: mostly modified outside
+        zck_target& zck()
+        {
+            if (!is_zchunck())  // TODO: REVIEW: should this be an assert?
+                throw std::invalid_argument("attempted to access zchunk data but there is none");
+            return *m_p_zck;
+        }
+
+        // TODO: rewrite outfile's ownership handling and processing to avoid sharing it with other
+        // types's implementations
+        void set_outfile(std::unique_ptr<FileIO> new_outfile)
+        {
+            m_outfile = std::move(new_outfile);
+        }
+
+        // TODO: rewrite outfile's ownership handling and processing to avoid sharing it with other
+        // types's implementations
+        std::unique_ptr<FileIO>& outfile() noexcept
+        {
+            return m_outfile;
+        }
+
+        const progress_callback_t& progress_callback() const
+        {
+            return m_progress_callback;
+        }
+
+        progress_callback_t set_progress_callback(progress_callback_t callback)
+        {
+            std::exchange(callback, m_progress_callback);
+            return callback;
+        }
+
+        const end_callback_t& end_callback() const
+        {
+            return m_end_callback;
+        }
+
+        end_callback_t set_end_callback(end_callback_t callback)
+        {
+            std::exchange(callback, m_end_callback);
+            return callback;
+        }
+
+        std::shared_ptr<Mirror> set_mirror_to_use(std::shared_ptr<Mirror> mirror)
+        {
+            std::exchange(mirror, m_used_mirror);
+            return mirror;
+        }
+
+        std::shared_ptr<Mirror> used_mirror() const noexcept
+        {
+            return m_used_mirror;
+        }
+
+        const std::string& effective_url() const noexcept
+        {
+            return m_effective_url;
+        }
+
+        void set_effective_url(const std::string& new_url)
+        {
+            // TODO: add some checks here
+            m_effective_url = new_url;
+        }
+
+        const std::vector<Checksum>& checksums() const
+        {
+            return m_checksums;
+        }
+
+        // TODO: consider making the whole set of checksums one value set when needed.
+        void add_checksum(Checksum value)
+        {
+            m_checksums.push_back(value);
+        }
 
     private:
+        bool m_is_zchunk = false;
+        bool m_resume = true;
+        bool m_no_cache = false;
+
+        std::string m_complete_url;
+        std::string m_path;
+        std::string m_base_url;
+        std::unique_ptr<FileIO> m_outfile;
+
+        fs::path m_filename;
+
+        std::size_t m_byterange_start = 0;
+        std::size_t m_byterange_end = 0;
+        std::string m_range;
+        std::ptrdiff_t m_expected_size = 0;
+        std::ptrdiff_t m_orig_size = 0;
+
+        progress_callback_t m_progress_callback;
+        end_callback_t m_end_callback;
+
+        // these are available checksums for the entire file
+        std::vector<Checksum> m_checksums;
+
+        std::shared_ptr<Mirror> m_used_mirror;
+        std::string m_effective_url;
+        std::unique_ptr<DownloaderError> m_error;  // TODO: check if it's used somewhere outside
+                                                   // this project, or use in tests at least.
+
+        std::unique_ptr<zck_target> m_p_zck;
+
         CacheControl m_cache_control;
     };
 

--- a/src/mirror.cpp
+++ b/src/mirror.cpp
@@ -118,7 +118,7 @@ namespace powerloader
 
     std::string Mirror::format_url(Target* target) const
     {
-        return fmt::format("{}/{}", m_url, target->target->path);
+        return fmt::format("{}/{}", m_url, target->target->path());
     }
 
     /** Sort mirrors. Penalize the error ones.

--- a/src/mirrors/oci.cpp
+++ b/src/mirrors/oci.cpp
@@ -108,7 +108,7 @@ namespace powerloader
 
     OCIMirror::AuthCallbackData* OCIMirror::get_data(Target* target) const
     {
-        auto [split_path, _] = split_path_tag(target->target->path);
+        auto [split_path, _] = split_path_tag(target->target->path());
         auto it = m_path_cb_map.find(split_path);
         if (it != m_path_cb_map.end())
         {
@@ -226,8 +226,9 @@ namespace powerloader
         if (data && !data->sha256sum.empty())
             return false;
 
-        if (std::none_of(target->target->checksums.begin(),
-                         target->target->checksums.end(),
+        const auto& checksums = target->target->checksums();
+        if (std::none_of(checksums.begin(),
+                         checksums.end(),
                          [](auto& ck) { return ck.type == ChecksumType::kSHA256; }))
             return true;
 
@@ -236,9 +237,9 @@ namespace powerloader
 
     std::string OCIMirror::format_url(Target* target) const
     {
-        std::string* checksum = nullptr;
+        const std::string* checksum = nullptr;
 
-        for (auto& ck : target->target->checksums)
+        for (const auto& ck : target->target->checksums())  // TODO: replace by std::find?
         {
             if (ck.type == ChecksumType::kSHA256)
                 checksum = &ck.checksum;
@@ -249,7 +250,7 @@ namespace powerloader
             auto* data = get_data(target);
             checksum = &data->sha256sum;
         }
-        auto [split_path, split_tag] = split_path_tag(target->target->path);
+        auto [split_path, split_tag] = split_path_tag(target->target->path());
         // https://ghcr.io/v2/wolfv/artifact/blobs/sha256:c5be3ea75353851e1fcf3a298af3b6cfd2af3d7ff018ce52657b6dbd8f986aa4
         return fmt::format(
             "{}/v2/{}/blobs/sha256:{}", this->url(), get_repo(split_path), *checksum);

--- a/src/mirrors/s3.cpp
+++ b/src/mirrors/s3.cpp
@@ -136,7 +136,7 @@ namespace powerloader
 
     std::string S3Mirror::format_url(Target* target) const
     {
-        return fmt::format("{}/{}", bucket_url, target->target->path);
+        return fmt::format("{}/{}", bucket_url, target->target->path());
     }
 
     bool S3Mirror::needs_preparation(Target* target) const

--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -23,8 +23,10 @@ PYBIND11_MODULE(pypowerloader, m)
 
     py::class_<DownloadTarget, std::shared_ptr<DownloadTarget>>(m, "DownloadTarget")
         .def(py::init<const std::string&, const std::string&, const fs::path&>())
-        .def_readonly("complete_url", &DownloadTarget::complete_url)
-        .def_readwrite("progress_callback", &DownloadTarget::progress_callback);
+        .def_property_readonly("complete_url", &DownloadTarget::complete_url)
+        .def_property("progress_callback",
+                      &DownloadTarget::progress_callback,
+                      &DownloadTarget::set_progress_callback);
 
     py::class_<Mirror, std::shared_ptr<Mirror>>(m, "Mirror")
         .def(py::init<const Context&, const std::string&>());

--- a/src/zck.hpp
+++ b/src/zck.hpp
@@ -29,9 +29,8 @@ namespace powerloader
         }
     };
 
-    class zck_target
+    struct zck_target
     {
-    public:
         // Zchunk download context
         zckDL* zck_dl = nullptr;
 
@@ -42,10 +41,10 @@ namespace powerloader
         fs::path zck_cache_file;
 
         // Total to download in zchunk file
-        std::uint64_t total_to_download;
+        std::uint64_t total_to_download = 0;
 
         // Amount already downloaded in zchunk file
-        std::uint64_t downloaded;
+        std::uint64_t downloaded = 0;
     };
 
     POWERLOADER_API zck_hash zck_hash_from_checksum(ChecksumType checksum_type);


### PR DESCRIPTION
Note that I initially modified `Target` and `DownloadTarget` together but they are too coupled with `Downloader` so here this is only `DownloadTarget` with some notes here I will do some bigger changes in the next PRs, which will also impact `Target` and `Downloader`.