### PR TITLE
Rewrite the interface of `Target` for encapsulation.

### DIFF
--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -83,7 +83,7 @@ namespace powerloader
 
         // TODO: why do we need to expose these three methods
         CURL* handle();
-        operator CURL*(); // TODO: consider making this `explicit` or remove it
+        operator CURL*();  // TODO: consider making this `explicit` or remove it
         CURL* ptr() const;
 
         CURLHandle& add_header(const std::string& header);

--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -83,7 +83,7 @@ namespace powerloader
 
         // TODO: why do we need to expose these three methods
         CURL* handle();
-        operator CURL*();
+        operator CURL*(); // TODO: consider making this `explicit` or remove it
         CURL* ptr() const;
 
         CURLHandle& add_header(const std::string& header);

--- a/include/powerloader/download_target.hpp
+++ b/include/powerloader/download_target.hpp
@@ -168,6 +168,11 @@ namespace powerloader
             return m_outfile;
         }
 
+        const std::unique_ptr<FileIO>& outfile() const noexcept
+        {
+            return m_outfile;
+        }
+
         const progress_callback_t& progress_callback() const
         {
             return m_progress_callback;

--- a/include/powerloader/errors.hpp
+++ b/include/powerloader/errors.hpp
@@ -93,17 +93,17 @@ namespace powerloader
         ErrorCode code;
         std::string reason;
 
-        bool is_serious() noexcept
+        bool is_serious() const noexcept
         {
             return (level == ErrorLevel::SERIOUS || level == ErrorLevel::FATAL);
         }
 
-        bool is_fatal() noexcept
+        bool is_fatal() const noexcept
         {
             return level == ErrorLevel::FATAL;
         }
 
-        void log()
+        void log() const
         {
             switch (level)
             {

--- a/include/powerloader/target.hpp
+++ b/include/powerloader/target.hpp
@@ -173,7 +173,7 @@ namespace powerloader
             return m_tried_mirrors;
         }
 
-        CURL* curl() const noexcept
+        CURLHandle* curl_handle() const noexcept
         {
             return m_curl_handle.get();
         }

--- a/include/powerloader/target.hpp
+++ b/include/powerloader/target.hpp
@@ -41,47 +41,183 @@ namespace powerloader
 
         ~Target();
 
-        std::shared_ptr<DownloadTarget> target;
-        fs::path temp_file;
-        std::string url_stub;
+        CbReturnCode call_end_callback(TransferStatus status);
 
-        bool resume = false;
-        std::size_t resume_count = 0;
-        std::ptrdiff_t original_offset;
+
+        // Mark the target as failed and returns the value returned by the end callback
+        CbReturnCode set_failed(DownloaderError error);
+
+        // Completes transfer that finished successfully.
+        void finalize_transfer(const std::string& effective_url);
+
+        bool set_retrying();
+
+        // Changes the state of this target IFF the downloaded file already exists (however it was
+        // produced).
+        void check_if_already_finished();
+
+        // Forces max speed (provided by context) for already prepared Target.
+        // Requirement: `prepare_for_transfer()` must have been called successfully before calling
+        // this function.
+        void set_to_max_speed();
+
+        void reset();
+        void reset_response();
+
+        void prepare_for_transfer(CURLM* multi_handle,
+                                  const std::string& full_url,
+                                  Protocol protocol);
+
+        void flush_target_file();
+
+        tl::expected<void, DownloaderError> finish_transfer(const std::string& effective_url);
+
+        void complete_mirror_usage(bool was_success,
+                                   const tl::expected<void, DownloaderError>& result);
+
+        bool can_retry_transfer_with_fewer_connections() const;
+        void lower_mirror_parallel_connections();
+
+        const DownloadTarget& target() const noexcept
+        {
+            assert(m_target);
+            return *m_target;
+        }
+
+        // TODO: don't allow external code from manipulating this internal target.
+        DownloadTarget& target() noexcept
+        {
+            assert(m_target);
+            return *m_target;
+        }
+
+        // TODO: don't expose ownership
+        const std::shared_ptr<Mirror>& mirror() const noexcept
+        {
+            assert(m_mirror);
+            return m_mirror;
+        }
+
+        // TODO: don't expose ownership
+        std::shared_ptr<Mirror>& mirror() noexcept
+        {
+            assert(m_mirror);
+            return m_mirror;
+        }
+
+        void change_mirror(std::shared_ptr<Mirror> mirror);
+
+        const fs::path temp_file() const noexcept
+        {
+            return m_temp_file;
+        }
+
+        bool writecb_required_range_written() const noexcept
+        {
+            return m_writecb_required_range_written;
+        }
+
+        HeaderCbState headercb_state() const noexcept
+        {
+            return m_headercb_state;
+        }
+
+        const std::string& headercb_interrupt_reason() const noexcept
+        {
+            return m_headercb_interrupt_reason;
+        }
+
+        int range_fail() const noexcept
+        {
+            return m_range_fail;
+        }
+
+        void reset_range_fail() noexcept
+        {
+            m_range_fail = false;
+        }
+
+        std::size_t retries() const noexcept
+        {
+            return m_retries;
+        }
+
+        DownloadState state() const noexcept
+        {
+            return m_state;
+        }
+
+        ZckState zck_state() const noexcept
+        {
+            return m_zck_state;
+        }
+
+        // TODO: refactor to avoid state being changed directly from outisde.
+        void set_zck_state(ZckState new_state) noexcept
+        {
+            m_zck_state = new_state;
+        }
+
+        const auto& errorbuffer() const noexcept
+        {
+            return m_errorbuffer;
+        }
+
+        const auto& mirrors() const noexcept
+        {
+            return m_mirrors;
+        }
+
+        const auto& tried_mirrors() const noexcept
+        {
+            return m_tried_mirrors;
+        }
+
+        CURL* curl() const noexcept
+        {
+            return m_curl_handle.get();
+        }
+
+    private:
+
+        std::shared_ptr<DownloadTarget> m_target;
+        fs::path m_temp_file;
+        std::string m_url_stub;
+
+        bool m_resume = false;
+        std::size_t m_resume_count = 0;
+        std::ptrdiff_t m_original_offset;
 
         // internal stuff
-        std::size_t retries = 0;
+        std::size_t m_retries = 0;
 
-        DownloadState state = DownloadState::kWAITING;
+        DownloadState m_state = DownloadState::kWAITING;
 
         // mirror list (or should we have a failure callback)
-        std::shared_ptr<Mirror> mirror = nullptr;
-        std::vector<std::shared_ptr<Mirror>> mirrors;
-        std::set<std::shared_ptr<Mirror>> tried_mirrors;
-        std::shared_ptr<Mirror> used_mirror = nullptr;
+        std::shared_ptr<Mirror> m_mirror;
+        std::vector<std::shared_ptr<Mirror>> m_mirrors;
+        std::set<std::shared_ptr<Mirror>> m_tried_mirrors;
+        std::shared_ptr<Mirror> m_used_mirror;
 
-        HeaderCbState headercb_state;
-        std::string headercb_interrupt_reason;
-        std::size_t writecb_received;
-        bool writecb_required_range_written;
+        HeaderCbState m_headercb_state;
+        std::string m_headercb_interrupt_reason;
+        std::size_t m_writecb_received;
+        bool m_writecb_required_range_written;
 
-        char errorbuffer[CURL_ERROR_SIZE] = {};
+        char m_errorbuffer[CURL_ERROR_SIZE] = {};
 
-        CbReturnCode callback_return_code;
+        std::unique_ptr<CURLHandle> m_curl_handle;
+        Protocol m_protocol;
 
-        std::unique_ptr<CURLHandle> curl_handle;
-        Protocol protocol;
+        Response m_response;
 
-        Response response;
+        bool m_range_fail = false;
+        ZckState m_zck_state;
 
-        bool range_fail = false;
-        ZckState zck_state;
-
-        const Context& ctx;
+        const Context& m_ctx;
 
         bool zck_running() const;
 
-        CbReturnCode call_end_callback(TransferStatus status);
         void reset_file(TransferStatus status);
 
         static int progress_callback(Target* ptr,
@@ -94,10 +230,14 @@ namespace powerloader
 
         void open_target_file();
 
-        void reset();
-
         bool check_filesize();
         bool check_checksums();
+
+        friend std::size_t zckwritecb(char* buffer, size_t size, size_t nitems, Target* self);
+        friend std::size_t zckheadercb(char* buffer,
+                                       std::size_t size,
+                                       std::size_t nitems,
+                                       Target* self);
     };
 }
 

--- a/include/powerloader/target.hpp
+++ b/include/powerloader/target.hpp
@@ -179,7 +179,6 @@ namespace powerloader
         }
 
     private:
-
         std::shared_ptr<DownloadTarget> m_target;
         fs::path m_temp_file;
         std::string m_url_stub;

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -630,9 +630,9 @@ namespace powerloader
                     // complete_url_in_path and target->base_url() doesn't have an
                     // alternatives like using mirrors, therefore they are handled
                     // differently
-                    std::string complete_url_or_base_url = complete_url_in_path
-                                                               ? current_target->target().path()
-                                                               : current_target->target().base_url();
+                    std::string complete_url_or_base_url
+                        = complete_url_in_path ? current_target->target().path()
+                                               : current_target->target().base_url();
                     if (can_retry_download(static_cast<int>(current_target->retries()),
                                            complete_url_or_base_url))
                     {
@@ -656,7 +656,6 @@ namespace powerloader
                         //     // if our resume file is too large we need to completely truncate it
                         //     current_target->original_offset = 0;
                         // }
-
                     }
                 }
 

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -522,7 +522,7 @@ namespace powerloader
 
             for (auto* target : m_running_transfers)
             {
-                if (target->curl() == msg->easy_handle)
+                if (target->curl_handle() && target->curl_handle()->handle() == msg->easy_handle)
                 {
                     current_target = target;
                     break;
@@ -558,7 +558,7 @@ namespace powerloader
             }
 
             // Cleanup
-            curl_multi_remove_handle(multi_handle, current_target->curl());
+            curl_multi_remove_handle(multi_handle, current_target->curl_handle());
 
             // call_end_callback()
             if (!result)

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -555,6 +555,7 @@ namespace powerloader
             if (!transfer_err)
             {
                 result = current_target->finish_transfer(effective_url);
+                transfer_err = !result;
             }
 
             // Cleanup

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -517,6 +517,10 @@ namespace powerloader
                 continue;
             }
 
+            // At this point, we received a message that must match a running transfer, otherwise
+            // something is broken.
+            assert(!m_running_transfers.empty());
+
             // TODO maybe refactor so that `msg` is passed to current target?
             Target* current_target = nullptr;
 

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -86,41 +86,41 @@ namespace powerloader
         if (msg->data.result != CURLE_OK)
         {
             // There was an error that is reported by CURLcode
-            if (msg->data.result == CURLE_WRITE_ERROR && target->writecb_required_range_written)
+            if (msg->data.result == CURLE_WRITE_ERROR && target->writecb_required_range_written())
             {
                 // Download was interrupted by writecb because
                 // user want only specified byte range of the
                 // target and the range was already downloaded
                 spdlog::info("Transfer was interrupted by writecb() because the required "
                              "range ({} - {}) was downloaded.",
-                             target->target->byterange_start(),
-                             target->target->byterange_end());
+                             target->target().byterange_start(),
+                             target->target().byterange_end());
             }
-            else if (target->headercb_state == HeaderCbState::kINTERRUPTED)
+            else if (target->headercb_state() == HeaderCbState::kINTERRUPTED)
             {
                 // Download was interrupted by header callback
                 return tl::unexpected(
                     DownloaderError{ ErrorLevel::FATAL,
                                      ErrorCode::PD_CBINTERRUPTED,
                                      fmt::format("Interrupted by header callback: {}",
-                                                 target->headercb_interrupt_reason) });
+                                                 target->headercb_interrupt_reason()) });
             }
 #ifdef WITH_ZCHUNK
-            else if (target->range_fail)
+            else if (target->range_fail())
             {
-                zckRange* range = zck_dl_get_range(target->target->zck().zck_dl);
+                zckRange* range = zck_dl_get_range(target->target().zck().zck_dl);
                 int range_count = zck_get_range_count(range);
-                if (target->mirror->stats().max_ranges >= range_count)
+                if (target->mirror()->stats().max_ranges >= range_count)
                 {
-                    target->mirror->change_max_ranges(range_count / 2);
+                    target->mirror()->change_max_ranges(range_count / 2);
                     spdlog::debug("Setting mirror max_ranges to {}",
-                                  target->mirror->stats().max_ranges);
+                                  target->mirror()->stats().max_ranges);
                 }
             }
-            else if (target->target->zck().zck_dl != nullptr
-                     && zck_is_error(zck_dl_get_zck(target->target->zck().zck_dl)) > 0)
+            else if (target->target().zck().zck_dl != nullptr
+                     && zck_is_error(zck_dl_get_zck(target->target().zck().zck_dl)) > 0)
             {
-                zckCtx* zck = zck_dl_get_zck(target->target->zck().zck_dl);
+                zckCtx* zck = zck_dl_get_zck(target->target().zck().zck_dl);
 
                 // Something went wrong while writing the zchunk file
                 if (zck_is_error(zck) == 1)
@@ -146,7 +146,7 @@ namespace powerloader
                                                 msg->data.result,
                                                 curl_easy_strerror(msg->data.result),
                                                 effective_url,
-                                                target->errorbuffer);
+                                                target->errorbuffer());
                 spdlog::error(error);
                 switch (msg->data.result)
                 {
@@ -210,7 +210,7 @@ namespace powerloader
     {
         assert(target);
 
-        if (target->mirrors.empty())
+        if (target->mirrors().empty())
         {
             return tl::unexpected(DownloaderError{
                 ErrorLevel::FATAL, ErrorCode::PD_MIRRORS, "No mirrors added for target" });
@@ -228,7 +228,7 @@ namespace powerloader
         // number of allowed failures equal to dd->allowed_mirror_failures.
         do
         {
-            for (const auto& mirror : target->mirrors)
+            for (const auto& mirror : target->mirrors())
             {
                 const auto mirror_stats = mirror->stats();
                 if (mirrors_iterated == 0)
@@ -237,7 +237,7 @@ namespace powerloader
                     {
                         reiterate = true;
                     }
-                    if (target->tried_mirrors.count(mirror))
+                    if (target->tried_mirrors().count(mirror))
                     {
                         // This mirror was already tried for this target
                         continue;
@@ -265,7 +265,7 @@ namespace powerloader
                 }
 
                 if (mirrors_iterated == 0 && mirror->protocol() == Protocol::kFTP
-                    && target->target->is_zchunck())
+                    && target->target().is_zchunck())
                 {
                     continue;
                 }
@@ -298,13 +298,13 @@ namespace powerloader
                 // This mirror looks suitable - use it
                 return mirror;
             }
-        } while (reiterate && target->retries < static_cast<std::size_t>(allowed_mirror_failures)
+        } while (reiterate && target->retries() < static_cast<std::size_t>(allowed_mirror_failures)
                  && ++mirrors_iterated < std::size_t(allowed_mirror_failures));
 
         return tl::unexpected(DownloaderError(
             { ErrorLevel::FATAL,
               ErrorCode::PD_NOURL,
-              fmt::format("No suitable mirror found for {}", target->target->complete_url()) }));
+              fmt::format("No suitable mirror found for {}", target->target().complete_url()) }));
     }
 
     // Select next target
@@ -316,15 +316,15 @@ namespace powerloader
             std::string full_url;
 
             // Pick only waiting targets
-            if (target->state != DownloadState::kWAITING)
+            if (target->state() != DownloadState::kWAITING)
                 continue;
 
             // Determine if path is a complete URL
-            bool complete_url_in_path = target->target->has_complete_url();
+            bool complete_url_in_path = target->target().has_complete_url();
 
-            bool have_mirrors = !target->mirrors.empty();
+            bool have_mirrors = !target->mirrors().empty();
             // Sanity check
-            if (target->target->base_url().empty() && !have_mirrors && !complete_url_in_path)
+            if (target->target().base_url().empty() && !have_mirrors && !complete_url_in_path)
             {
                 // Used relative path with empty internal mirrorlist and no basepath specified!
                 return tl::unexpected(DownloaderError{
@@ -336,7 +336,7 @@ namespace powerloader
             // Prepare full target URL
             if (complete_url_in_path)
             {
-                full_url = target->target->complete_url();
+                full_url = target->target().complete_url();
             }
             else
             {
@@ -344,6 +344,8 @@ namespace powerloader
                 auto res = select_suitable_mirror(target);
                 if (!res)
                 {
+                    // TODO: review this: why is the callback called without changing the state
+                    // of the target? (see Target::set_failed() for example).
                     target->call_end_callback(TransferStatus::kERROR);
                     return tl::unexpected(res.error());
                 }
@@ -357,7 +359,7 @@ namespace powerloader
                 if (mirror && !mirror->needs_preparation(target))
                 {
                     full_url = mirror->format_url(target);
-                    target->mirror = mirror;
+                    target->change_mirror(mirror);
                 }
                 else
                 {
@@ -365,7 +367,7 @@ namespace powerloader
                     if (!mirror->needs_preparation(target))
                     {
                         spdlog::info("Currently there is no free mirror for {}",
-                                     target->target->path());
+                                     target->target().path());
                     }
                 }
             }
@@ -379,19 +381,17 @@ namespace powerloader
                 spdlog::info("Skipping {} because offline mode is active", full_url);
 
                 // Mark the target as failed
-                target->state = DownloadState::kFAILED;
-                target->target->set_error(DownloaderError{
+                const auto cb_ret = target->set_failed(DownloaderError{
                     ErrorLevel::FATAL,
                     ErrorCode::PD_NOURL,
                     "Cannot download: offline mode is specified and no local URL is available." });
 
-                /*auto cb_ret = */ target->call_end_callback(TransferStatus::kERROR);
                 // TODO
                 // if (cb_ret == CbReturnCode::kERROR || failfast)
                 // {
                 //     throw fatal_download_error(fmt::format(
                 //         "Cannot download {}: Offline mode is specified and no local URL is
-                //         available", target->target->path()));
+                //         available", target->target().path()));
                 // }
             }
 
@@ -399,9 +399,8 @@ namespace powerloader
             if (mirror || !full_url.empty())
             {
                 // Note: mirror is nullptr if base_url is used
-                target->mirror = mirror;
-                // reset response
-                target->response = Response();
+                target->change_mirror(mirror);
+                target->reset_response();
                 return std::make_pair(target, full_url);
             }
         }
@@ -426,9 +425,9 @@ namespace powerloader
         if (!target)  // Nothing to do
             return true;
 
-        if (target->mirror && target->mirror->need_wait_for_retry())
+        if (target->mirror() && target->mirror()->need_wait_for_retry())
         {
-            std::this_thread::sleep_until(target->mirror->next_retry());
+            std::this_thread::sleep_until(target->mirror()->next_retry());
         }
 
         *candidate_found = true;
@@ -452,169 +451,10 @@ namespace powerloader
         // protocol = lr_detect_protocol(full_url);
         protocol = Protocol::kHTTP;
 
-        // Prepare CURL easy handle
-        target->curl_handle.reset(new CURLHandle(ctx));
-        CURLHandle& h = *(target->curl_handle);
+        target->prepare_for_transfer(multi_handle, full_url, protocol);
 
-        if (target->mirror && target->mirror->needs_preparation(target))
-        {
-            target->mirror->prepare(target->target->path(), h);
-            target->state = DownloadState::kPREPARATION;
-
-            curl_multi_add_handle(multi_handle, h);
-
-            // Add the transfer to the list of running transfers
-            m_running_transfers.push_back(target);
-
-            return true;
-        }
-
-        // Set URL
-        h.url(full_url);
-
-        // Prepare FILE
-#ifdef WITH_ZCHUNK
-        if (!target->target->is_zchunck())
-        {
-#endif
-            target->open_target_file();
-            target->writecb_received = 0;
-            target->writecb_required_range_written = false;
-#ifdef WITH_ZCHUNK
-        }
-        // If file is zchunk, prep it
-        if (target->target->is_zchunck())
-        {
-            if (!target->target->outfile())
-            {
-                spdlog::info("zck: opening file {}", target->temp_file.string());
-                target->open_target_file();
-                target->writecb_received = 0;
-                target->writecb_required_range_written = false;
-            }
-
-            if (!check_zck(target))
-            {
-                spdlog::error("Unable to initialize zchunk file!");
-                target->state = DownloadState::kFAILED;
-                target->target->set_error(DownloaderError{
-                    ErrorLevel::FATAL, ErrorCode::PD_ZCK, "Unable to initialize zchunk file" });
-            }
-
-            // If zchunk is finished, we're done, so move to next target
-            if (target->zck_state == ZckState::kFINISHED)
-            {
-                spdlog::info("Target fully downloaded: {}", target->target->path());
-                target->state = DownloadState::kFINISHED;
-                target->reset();
-                target->headercb_interrupt_reason.clear();
-                target->call_end_callback(TransferStatus::kSUCCESSFUL);
-                return prepare_next_transfer(candidate_found);
-            }
-        }
-#endif /* WITH_ZCHUNK */
-
-        if (target->resume && target->resume_count >= ctx.max_resume_count)
-        {
-            target->resume = false;
-            spdlog::info("Download resume ignored, maximal number of attempts has been reached");
-        }
-
-        // Resume - set offset to resume incomplete download
-        if (target->resume)
-        {
-            target->resume_count++;
-            if (target->original_offset == -1)
-            {
-                // Determine offset
-                target->target->outfile()->seek(0L, SEEK_END);
-                std::ptrdiff_t determined_offset = target->target->outfile()->tell();
-
-                if (determined_offset == -1)
-                {
-                    // An error while determining offset => download the whole file again
-                    determined_offset = 0;
-                }
-                target->original_offset = determined_offset;
-            }
-
-            curl_off_t used_offset = target->original_offset;
-
-            spdlog::info("Trying to resume from offset {}", used_offset);
-            h.setopt(CURLOPT_RESUME_FROM_LARGE, used_offset);
-        }
-
-        if (target->target->byterange_start() > 0)
-        {
-            assert(!target->target->resume() && target->target->range().empty());
-            h.setopt(CURLOPT_RESUME_FROM_LARGE, (curl_off_t) target->target->byterange_start());
-        }
-
-        // Set range if user specified one
-        if (!target->target->range().empty())
-        {
-            assert(!target->target->resume() && !target->target->byterange_start());
-            h.setopt(CURLOPT_RANGE, target->target->range());
-        }
-
-        // Prepare progress callback
-        target->callback_return_code = CbReturnCode::kOK;
-        if (target->target->progress_callback())
-        {
-            h.setopt(CURLOPT_XFERINFOFUNCTION, &Target::progress_callback);
-            h.setopt(CURLOPT_NOPROGRESS, 0);
-            h.setopt(CURLOPT_XFERINFODATA, target);
-        }
-
-        // Prepare header callback
-        h.setopt(CURLOPT_HEADERFUNCTION, &Target::header_callback);
-        h.setopt(CURLOPT_HEADERDATA, target);
-
-        // Prepare write callback
-        h.setopt(CURLOPT_WRITEFUNCTION, &Target::write_callback);
-        h.setopt(CURLOPT_WRITEDATA, target);
-
-        // Set extra HTTP headers
-        if (target->mirror)
-        {
-            h.add_headers(target->mirror->get_auth_headers(target->target->path()));
-        }
-
-        // accept default curl supported encodings
-        h.accept_encoding();
-        h.add_headers(ctx.additional_httpheaders);
-
-        if (target->target->no_cache())
-        {
-            // Add headers that tell proxy to serve us fresh data
-            h.add_header("Cache-Control: no-cache");
-            h.add_header("Pragma: no-cache");
-        }
-        else
-        {
-            target->target->add_handle_options(h);
-        }
-
-        // Add the new handle to the curl multi handle
-        CURL* handle = h;
-        CURLMcode cm_rc = curl_multi_add_handle(multi_handle, handle);
-        assert(cm_rc == CURLM_OK);
-
-        // Set the state of transfer as running
-        target->state = DownloadState::kRUNNING;
-
-        // Increase running transfers counter for mirror
-        if (target->mirror)
-        {
-            target->mirror->increase_running_transfers();
-        }
-
-        // Set the state of header callback for this transfer
-        target->headercb_state = HeaderCbState::kDEFAULT;
-        target->headercb_interrupt_reason.clear();
-
-        // Set protocol of the target
-        target->protocol = protocol;
+        if (target->zck_state() == ZckState::kFINISHED)
+            return prepare_next_transfer(candidate_found);
 
         // Add the transfer to the list of running transfers
         m_running_transfers.push_back(target);
@@ -669,8 +509,7 @@ namespace powerloader
     bool Downloader::check_msgs(bool lfailfast)
     {
         int msgs_in_queue;
-        CURLMsg* msg;
-        while ((msg = curl_multi_info_read(multi_handle, &msgs_in_queue)))
+        while (CURLMsg* msg = curl_multi_info_read(multi_handle, &msgs_in_queue))
         {
             if (msg->msg != CURLMSG_DONE)
             {
@@ -680,9 +519,10 @@ namespace powerloader
 
             // TODO maybe refactor so that `msg` is passed to current target?
             Target* current_target = nullptr;
+
             for (auto* target : m_running_transfers)
             {
-                if (target->curl_handle->ptr() == msg->easy_handle)
+                if (target->curl() == msg->easy_handle)
                 {
                     current_target = target;
                     break;
@@ -691,14 +531,14 @@ namespace powerloader
 
             assert(current_target);
 
-            char* tmp_effective_url;
+            char* tmp_effective_url = nullptr;
 
             curl_easy_getinfo(msg->easy_handle, CURLINFO_EFFECTIVE_URL, &tmp_effective_url);
 
             // Make the effective url persistent to survive the curl_easy_cleanup()
             std::string effective_url(tmp_effective_url);
 
-            spdlog::info("Download finished {}", current_target->target->path());
+            spdlog::info("Download finished {}", current_target->target().path());
 
             // Check status of finished transfer
             bool transfer_err = false;
@@ -710,114 +550,15 @@ namespace powerloader
                 transfer_err = true;
             }
 
-            if (current_target->target->outfile() && current_target->target->outfile()->open())
+            current_target->flush_target_file();
+
+            if (!transfer_err)
             {
-                current_target->target->outfile()->flush();
+                result = current_target->finish_transfer(effective_url);
             }
 
-            if (transfer_err)
-                goto transfer_error;
-
-#ifdef WITH_ZCHUNK
-            if (current_target->target->is_zchunck())
-            {
-                if (current_target->zck_state == ZckState::kHEADER_LEAD)
-                {
-                    if (!zck_read_lead(current_target))
-                        goto transfer_error;
-                }
-                else if (current_target->zck_state == ZckState::kHEADER)
-                {
-                    if (current_target->mirror->stats().max_ranges > 0
-                        && current_target->mirror->protocol() == Protocol::kHTTP
-                        && !zck_valid_header(current_target))
-                    {
-                        goto transfer_error;
-                    }
-                }
-                else if (current_target->zck_state == ZckState::kBODY)
-                {
-                    if (current_target->mirror->stats().max_ranges > 0
-                        && current_target->mirror->protocol() == Protocol::kHTTP)
-                    {
-                        zckCtx* zck = zck_dl_get_zck(current_target->target->zck().zck_dl);
-                        if (zck == nullptr)
-                        {
-                            spdlog::error("Unable to get zchunk file from download context");
-                            result = tl::unexpected(DownloaderError{
-                                ErrorLevel::SERIOUS,
-                                ErrorCode::PD_ZCK,
-                                "Unable to get zchunk file from download context" });
-                            goto transfer_error;
-                        }
-                        if (zck_failed_chunks(zck) == 0 && zck_missing_chunks(zck) == 0)
-                        {
-                            current_target->zck_state = ZckState::kFINISHED;
-                        }
-                    }
-                    else
-                    {
-                        current_target->zck_state = ZckState::kFINISHED;
-                    }
-                }
-                if (current_target->zck_state == ZckState::kFINISHED)
-                {
-                    zckCtx* zck = zck_init_read(current_target);
-                    if (!zck)
-                        goto transfer_error;
-                    if (zck_validate_checksums(zck) < 1)
-                    {
-                        zck_free(&zck);
-                        spdlog::error("At least one of the zchunk checksums doesn't match in {}",
-                                      effective_url);
-
-                        result = tl::unexpected(DownloaderError{
-                            ErrorLevel::SERIOUS,
-                            ErrorCode::PD_BADCHECKSUM,
-                            fmt::format("At least one of the zchunk checksums doesn't match in {}",
-                                        effective_url) });
-
-                        goto transfer_error;
-                    }
-                    zck_free(&zck);
-                }
-            }
-            else
-            {
-#endif
-                if (current_target->target->outfile())
-                {
-                    // New file was downloaded
-                    if (!transfer_err && !current_target->check_filesize())
-                    {
-                        result = tl::unexpected(
-                            DownloaderError({ ErrorLevel::SERIOUS,
-                                              ErrorCode::PD_BADCHECKSUM,
-                                              "Result file does not have expected filesize" }));
-                        transfer_err = true;
-                        goto transfer_error;
-                    }
-                    if (!transfer_err && !current_target->check_checksums())
-                    {
-                        result = tl::unexpected(
-                            DownloaderError({ ErrorLevel::SERIOUS,
-                                              ErrorCode::PD_BADCHECKSUM,
-                                              "Result file does not have expected checksum" }));
-                        transfer_err = true;
-                        goto transfer_error;
-                    }
-                    if (!result)
-                    {
-                        current_target->reset_file(TransferStatus::kERROR);
-                    }
-                }
-#ifdef WITH_ZCHUNK
-            }
-#endif
-
-        transfer_error:
             // Cleanup
-            curl_multi_remove_handle(multi_handle, current_target->curl_handle->ptr());
+            curl_multi_remove_handle(multi_handle, current_target->curl());
 
             // call_end_callback()
             if (!result)
@@ -826,29 +567,16 @@ namespace powerloader
             }
             current_target->reset();
 
-            current_target->headercb_interrupt_reason.clear();
-
             m_running_transfers.erase(
                 std::find(m_running_transfers.begin(), m_running_transfers.end(), current_target));
 
-            // TODO check if we were preparing here?
-            current_target->tried_mirrors.insert(current_target->mirror);
-
-            if (current_target->mirror)
-            {
-                bool success = transfer_err == false;
-                current_target->mirror->update_statistics(success);
-                if (ctx.adaptive_mirror_sorting)
-                    sort_mirrors(current_target->mirrors,
-                                 current_target->mirror,
-                                 success,
-                                 result.error().is_serious());
-            }
+            // TODO: consider moving this call inside Target::finis_transfer()
+            current_target->complete_mirror_usage(transfer_err == false, result);
 
             // There was an error during transfer
             if (!result)
             {
-                // int complete_url_in_path = strstr(target->target->path(), "://") ? 1 : 0;
+                // int complete_url_in_path = strstr(target->target().path(), "://") ? 1 : 0;
                 int complete_url_in_path = false;
 
                 bool retry = false;
@@ -856,10 +584,10 @@ namespace powerloader
                 spdlog::error("Error during transfer");
 
                 // Call mirrorfailure callback
-                // LrMirrorFailureCb mf_cb = target->target->mirrorfailurecb;
+                // LrMirrorFailureCb mf_cb = target->target().mirrorfailurecb;
                 // if (mf_cb)
                 // {
-                //     int rc = mf_cb(target->target->cbdata,
+                //     int rc = mf_cb(target->target().cbdata,
                 //                    transfer_err->message,
                 //                    effective_url);
                 //     if (rc == LR_CB_ABORT)
@@ -888,40 +616,24 @@ namespace powerloader
 
                 if (!result.error().is_fatal())
                 {
-                    const auto& current_mirror = current_target->mirror;
-                    const auto mirror_stats = current_mirror->stats();
                     // Temporary error (serious_error) during download occurred and
                     // another transfers are running or there are successful transfers
                     // and fewer failed transfers than tried parallel connections. It may be
                     // mirror is OK but accepts fewer parallel connections.
-                    if (result.error().is_serious() && current_mirror
-                        && (current_mirror->has_running_transfers()
-                            || (mirror_stats.successful_transfers > 0
-                                && mirror_stats.failed_transfers
-                                       < mirror_stats.max_tried_parallel_connections)))
+                    if (result.error().is_serious()
+                        && current_target->can_retry_transfer_with_fewer_connections())
                     {
                         spdlog::info("Lower maximum of parallel connections for mirror");
-                        if (current_mirror->has_running_transfers())
-                        {
-                            current_mirror->set_allowed_parallel_connections(
-                                mirror_stats.running_transfers);
-                        }
-                        else
-                        {
-                            current_mirror->set_allowed_parallel_connections(1);
-                        }
-
-                        // Give used mirror another chance
-                        current_target->tried_mirrors.erase(current_mirror);
+                        current_target->lower_mirror_parallel_connections();
                     }
 
                     // complete_url_in_path and target->base_url() doesn't have an
                     // alternatives like using mirrors, therefore they are handled
                     // differently
                     std::string complete_url_or_base_url = complete_url_in_path
-                                                               ? current_target->target->path()
-                                                               : current_target->target->base_url();
-                    if (can_retry_download(static_cast<int>(current_target->retries),
+                                                               ? current_target->target().path()
+                                                               : current_target->target().base_url();
+                    if (can_retry_download(static_cast<int>(current_target->retries()),
                                            complete_url_or_base_url))
                     {
                         // Try another mirror or retry
@@ -933,9 +645,10 @@ namespace powerloader
                         {
                             spdlog::info("Ignore error - Try another mirror");
                         }
-                        current_target->state = DownloadState::kWAITING;
-                        current_target->retries++;
                         retry = true;
+                        const auto is_ready_to_retry = current_target->set_retrying();
+                        if (!is_ready_to_retry)
+                            return false;
 
                         // range fail
                         // if (status_code == 416)
@@ -943,32 +656,18 @@ namespace powerloader
                         //     // if our resume file is too large we need to completely truncate it
                         //     current_target->original_offset = 0;
                         // }
-#ifdef WITH_ZCHUNK
-                        if (!current_target->target->is_zchunck()
-                            || current_target->zck_state == ZckState::kHEADER)
-                        {
-#endif
-                            // Truncate file - remove downloaded garbage (error html page etc.)
-                            if (!current_target->truncate_transfer_file())
-                                return false;
-#ifdef WITH_ZCHUNK
-                        }
-#endif
+
                     }
                 }
 
                 if (!retry)
                 {
                     // No more mirrors to try or base_url used or fatal error
-                    current_target->state = DownloadState::kFAILED;
-
-                    // Call end callback
-                    CbReturnCode rc = current_target->call_end_callback(TransferStatus::kERROR);
                     spdlog::error("Retries exceeded for {}",
-                                  current_target->target->complete_url());
+                                  current_target->target().complete_url());
 
                     assert(!result);
-                    current_target->target->set_error(result.error());
+                    const CbReturnCode rc = current_target->set_failed(result.error());
 
                     if (lfailfast || rc == CbReturnCode::kERROR)
                     {
@@ -986,53 +685,8 @@ namespace powerloader
             }
             else
             {
-#ifdef WITH_ZCHUNK
                 // No error encountered, transfer finished successfully
-                if (current_target->target->is_zchunck()
-                    && current_target->zck_state != ZckState::kFINISHED)
-                {
-                    current_target->state = DownloadState::kWAITING;
-                    current_target->tried_mirrors.erase(current_target->mirror);
-                }
-                else
-                {
-#endif /* WITH_ZCHUNK */
-                    if (current_target->state == DownloadState::kRUNNING)
-                    {
-                        current_target->state = DownloadState::kFINISHED;
-                    }
-                    else if (current_target->state == DownloadState::kPREPARATION)
-                    {
-                        current_target->state = DownloadState::kWAITING;
-                    }
-
-                    // Remove xattr that states that the file is being downloaded
-                    // by librepo, because the file is now completely downloaded
-                    // and the xattr is not needed (is is useful only for resuming)
-                    // remove_librepo_xattr(target->target);
-
-                    // For "mirror preparation" we need to call finalize_transfer here!
-                    current_target->curl_handle->finalize_transfer();
-
-                    // only call the end callback if actually finished the download target
-                    if (current_target->state == DownloadState::kFINISHED)
-                    {
-                        CbReturnCode rc
-                            = current_target->call_end_callback(TransferStatus::kSUCCESSFUL);
-                        if (rc == CbReturnCode::kERROR)
-                        {
-                            throw fatal_download_error("Interrupted by error from end callback");
-                        }
-                    }
-#ifdef WITH_ZCHUNK
-                }
-#endif /* WITH_ZCHUNK */
-                if (current_target->mirror)
-                {
-                    current_target->target->set_mirror_to_use(current_target->mirror);
-                }
-
-                current_target->target->set_effective_url(effective_url);
+                current_target->finalize_transfer(effective_url);
             }
 
             if (fail_fast_err)
@@ -1055,12 +709,7 @@ namespace powerloader
 
         for (auto* target : m_targets)
         {
-            if (target->target->already_downloaded())
-            {
-                spdlog::info("Found already downloaded file!");
-                target->call_end_callback(TransferStatus::kALREADYEXISTS);
-                target->state = DownloadState::kFINISHED;
-            }
+            target->check_if_already_finished();
         }
 
         prepare_next_transfers();
@@ -1079,10 +728,9 @@ namespace powerloader
                 curl_multi_cleanup(multi_handle);
                 for (auto& target : m_running_transfers)
                 {
-                    target->target->set_error(DownloaderError{ ErrorLevel::FATAL,
-                                                               ErrorCode::PD_INTERRUPTED,
-                                                               "Download interrupted by error" });
-                    target->call_end_callback(TransferStatus::kERROR);
+                    target->set_failed(DownloaderError{ ErrorLevel::FATAL,
+                                                        ErrorCode::PD_INTERRUPTED,
+                                                        "Download interrupted by error" });
                 }
                 return false;
             }
@@ -1160,9 +808,7 @@ namespace powerloader
 
         for (auto& current_target : m_running_transfers)
         {
-            assert(ctx.max_speed_limit > 0);
-            current_target->curl_handle->setopt(CURLOPT_MAX_RECV_SPEED_LARGE,
-                                                (curl_off_t) ctx.max_speed_limit);
+            current_target->set_to_max_speed();
         }
 
         return true;

--- a/src/mirror.cpp
+++ b/src/mirror.cpp
@@ -118,7 +118,7 @@ namespace powerloader
 
     std::string Mirror::format_url(Target* target) const
     {
-        return fmt::format("{}/{}", m_url, target->target->path());
+        return fmt::format("{}/{}", m_url, target->target().path());
     }
 
     /** Sort mirrors. Penalize the error ones.

--- a/src/mirrors/oci.cpp
+++ b/src/mirrors/oci.cpp
@@ -108,7 +108,7 @@ namespace powerloader
 
     OCIMirror::AuthCallbackData* OCIMirror::get_data(Target* target) const
     {
-        auto [split_path, _] = split_path_tag(target->target->path());
+        auto [split_path, _] = split_path_tag(target->target().path());
         auto it = m_path_cb_map.find(split_path);
         if (it != m_path_cb_map.end())
         {
@@ -195,7 +195,7 @@ namespace powerloader
                     assert(starts_with(digest, "sha256:"));
 
                     // For some reason target->target isn't available here?
-                    // cbdata->target->target->checksums.push_back(
+                    // cbdata->target().target->checksums.push_back(
                     //     Checksum{ChecksumType::kSHA256, digest.substr(sizeof("sha256:") - 1)}
                     // );
 
@@ -225,7 +225,7 @@ namespace powerloader
         if (data && !data->sha256sum.empty())
             return false;
 
-        const auto& checksums = target->target->checksums();
+        const auto& checksums = target->target().checksums();
         if (std::none_of(checksums.begin(),
                          checksums.end(),
                          [](auto& ck) { return ck.type == ChecksumType::kSHA256; }))
@@ -238,7 +238,7 @@ namespace powerloader
     {
         const std::string* checksum = nullptr;
 
-        for (const auto& ck : target->target->checksums())  // TODO: replace by std::find?
+        for (const auto& ck : target->target().checksums())  // TODO: replace by std::find?
         {
             if (ck.type == ChecksumType::kSHA256)
                 checksum = &ck.checksum;
@@ -249,7 +249,7 @@ namespace powerloader
             auto* data = get_data(target);
             checksum = &data->sha256sum;
         }
-        auto [split_path, split_tag] = split_path_tag(target->target->path());
+        auto [split_path, split_tag] = split_path_tag(target->target().path());
         // https://ghcr.io/v2/wolfv/artifact/blobs/sha256:c5be3ea75353851e1fcf3a298af3b6cfd2af3d7ff018ce52657b6dbd8f986aa4
         return fmt::format(
             "{}/v2/{}/blobs/sha256:{}", this->url(), get_repo(split_path), *checksum);

--- a/src/mirrors/s3.cpp
+++ b/src/mirrors/s3.cpp
@@ -136,7 +136,7 @@ namespace powerloader
 
     std::string S3Mirror::format_url(Target* target) const
     {
-        return fmt::format("{}/{}", bucket_url, target->target->path());
+        return fmt::format("{}/{}", bucket_url, target->target().path());
     }
 
     bool S3Mirror::needs_preparation(Target*) const

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -566,6 +566,7 @@ namespace powerloader
                 reset();
                 call_end_callback(
                     TransferStatus::kSUCCESSFUL);  // TODO: do something with the result?
+                return;
             }
         }
 #endif /* WITH_ZCHUNK */

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -129,9 +129,8 @@ namespace powerloader
         m_temp_file = fn.replace_extension(fn.extension().string() + PARTEXT);
         spdlog::info("Opening file {}", m_temp_file.string());
 
-        const auto open_mode = fs::exists(m_temp_file) && m_resume
-                                   ? FileIO::append_update_binary
-                                   : FileIO::write_update_binary;
+        const auto open_mode = fs::exists(m_temp_file) && m_resume ? FileIO::append_update_binary
+                                                                   : FileIO::write_update_binary;
 
         std::error_code ec;
         m_target->set_outfile(std::make_unique<FileIO>(m_temp_file, open_mode, ec));
@@ -507,7 +506,7 @@ namespace powerloader
         assert(m_curl_handle);
         assert(m_ctx.max_speed_limit > 0);
         m_curl_handle->setopt(CURLOPT_MAX_RECV_SPEED_LARGE,
-                                            static_cast<curl_off_t>(m_ctx.max_speed_limit));
+                              static_cast<curl_off_t>(m_ctx.max_speed_limit));
     }
 
     void Target::reset_response()
@@ -515,7 +514,9 @@ namespace powerloader
         m_response = {};
     }
 
-    void Target::prepare_for_transfer(CURLM* multi_handle, const std::string& full_url, Protocol protocol)
+    void Target::prepare_for_transfer(CURLM* multi_handle,
+                                      const std::string& full_url,
+                                      Protocol protocol)
     {
         // Prepare CURL easy handle
         m_curl_handle.reset(new CURLHandle(m_ctx));
@@ -563,7 +564,8 @@ namespace powerloader
                 spdlog::info("Target fully downloaded: {}", m_target->path());
                 m_state = DownloadState::kFINISHED;
                 reset();
-                call_end_callback(TransferStatus::kSUCCESSFUL); // TODO: do something with the result?
+                call_end_callback(
+                    TransferStatus::kSUCCESSFUL);  // TODO: do something with the result?
             }
         }
 #endif /* WITH_ZCHUNK */
@@ -672,7 +674,6 @@ namespace powerloader
 
     tl::expected<void, DownloaderError> Target::finish_transfer(const std::string& effective_url)
     {
-
 #ifdef WITH_ZCHUNK
         if (m_target->is_zchunck())
         {
@@ -683,8 +684,7 @@ namespace powerloader
             }
             else if (m_zck_state == ZckState::kHEADER)
             {
-                if (m_mirror->stats().max_ranges > 0
-                    && m_mirror->protocol() == Protocol::kHTTP
+                if (m_mirror->stats().max_ranges > 0 && m_mirror->protocol() == Protocol::kHTTP
                     && !zck_valid_header(*this))
                 {
                     return {};
@@ -692,8 +692,7 @@ namespace powerloader
             }
             else if (m_zck_state == ZckState::kBODY)
             {
-                if (m_mirror->stats().max_ranges > 0
-                    && m_mirror->protocol() == Protocol::kHTTP)
+                if (m_mirror->stats().max_ranges > 0 && m_mirror->protocol() == Protocol::kHTTP)
                 {
                     zckCtx* zck = zck_dl_get_zck(m_target->zck().zck_dl);
                     if (zck == nullptr)
@@ -722,7 +721,7 @@ namespace powerloader
                     return {};
                 if (zck_validate_checksums(zck) < 1)
                 {
-                    zck_free(&zck); // TODO: add RAII to handle that
+                    zck_free(&zck);  // TODO: add RAII to handle that
                     spdlog::error("At least one of the zchunk checksums doesn't match in {}",
                                   effective_url);
 
@@ -732,7 +731,7 @@ namespace powerloader
                         fmt::format("At least one of the zchunk checksums doesn't match in {}",
                                     effective_url) });
                 }
-                zck_free(&zck); // TODO: check if it's a leak when not reached
+                zck_free(&zck);  // TODO: check if it's a leak when not reached
             }
         }
         else
@@ -745,15 +744,17 @@ namespace powerloader
                 // New file was downloaded
                 if (!check_filesize())
                 {
-                    result = tl::unexpected(DownloaderError{ ErrorLevel::SERIOUS,
-                                          ErrorCode::PD_BADCHECKSUM,
-                                          "Result file does not have expected filesize" });
+                    result = tl::unexpected(
+                        DownloaderError{ ErrorLevel::SERIOUS,
+                                         ErrorCode::PD_BADCHECKSUM,
+                                         "Result file does not have expected filesize" });
                 }
                 if (!check_checksums())
                 {
-                    result = tl::unexpected(DownloaderError{ ErrorLevel::SERIOUS,
-                                          ErrorCode::PD_BADCHECKSUM,
-                                          "Result file does not have expected checksum" });
+                    result = tl::unexpected(
+                        DownloaderError{ ErrorLevel::SERIOUS,
+                                         ErrorCode::PD_BADCHECKSUM,
+                                         "Result file does not have expected checksum" });
                 }
             }
 
@@ -777,7 +778,8 @@ namespace powerloader
         }
     }
 
-    void Target::complete_mirror_usage(bool was_success, const tl::expected<void, DownloaderError>& result)
+    void Target::complete_mirror_usage(bool was_success,
+                                       const tl::expected<void, DownloaderError>& result)
     {
         // TODO check if we were preparing here?
         if (m_mirror)
@@ -785,10 +787,8 @@ namespace powerloader
             m_tried_mirrors.insert(m_mirror);
             m_mirror->update_statistics(was_success);
             if (m_ctx.adaptive_mirror_sorting)
-                sort_mirrors(m_mirrors,
-                             m_mirror,
-                             was_success,
-                             result ? false : result.error().is_serious());
+                sort_mirrors(
+                    m_mirrors, m_mirror, was_success, result ? false : result.error().is_serious());
         }
     }
 
@@ -828,8 +828,7 @@ namespace powerloader
         m_retries++;
 
 #ifdef WITH_ZCHUNK
-        if (!m_target->is_zchunck()
-            || m_zck_state == ZckState::kHEADER)
+        if (!m_target->is_zchunck() || m_zck_state == ZckState::kHEADER)
         {
 #endif
             // Truncate file - remove downloaded garbage (error html page etc.)
@@ -846,8 +845,7 @@ namespace powerloader
     void Target::finalize_transfer(const std::string& effective_url)
     {
 #ifdef WITH_ZCHUNK
-        if (m_target->is_zchunck()
-            && m_zck_state != ZckState::kFINISHED)
+        if (m_target->is_zchunck() && m_zck_state != ZckState::kFINISHED)
         {
             m_state = DownloadState::kWAITING;
             if (m_mirror)
@@ -877,8 +875,7 @@ namespace powerloader
             // only call the end callback if actually finished the download target
             if (m_state == DownloadState::kFINISHED)
             {
-                const CbReturnCode rc
-                    = call_end_callback(TransferStatus::kSUCCESSFUL);
+                const CbReturnCode rc = call_end_callback(TransferStatus::kSUCCESSFUL);
                 if (rc == CbReturnCode::kERROR)
                 {
                     throw fatal_download_error("Interrupted by error from end callback");

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -5,15 +5,15 @@
 
 namespace powerloader
 {
-    Target::Target(const Context& lctx,
+    Target::Target(const Context& ctx,
                    std::shared_ptr<DownloadTarget> dl_target,
-                   std::vector<std::shared_ptr<Mirror>> lmirrors)
-        : target(dl_target)
-        , resume(dl_target->resume())
-        , original_offset(-1)
-        , state(DownloadState::kWAITING)
-        , mirrors(lmirrors)
-        , ctx(lctx)
+                   std::vector<std::shared_ptr<Mirror>> mirrors)
+        : m_target(dl_target)
+        , m_resume(dl_target->resume())
+        , m_original_offset(-1)
+        , m_state(DownloadState::kWAITING)
+        , m_mirrors(std::move(mirrors))
+        , m_ctx(ctx)
     {
     }
 
@@ -25,7 +25,7 @@ namespace powerloader
     bool Target::zck_running() const
     {
 #ifdef WITH_ZCHUNK
-        return target->is_zchunck() && zck_state != ZckState::kFINISHED;
+        return m_target->is_zchunck() && m_zck_state != ZckState::kFINISHED;
 #else
         return false;
 #endif
@@ -33,36 +33,38 @@ namespace powerloader
 
     void Target::reset()
     {
-        if (target->outfile() && !zck_running())
+        if (m_target->outfile() && !zck_running())
         {
             std::error_code ec;
-            target->outfile()->close(ec);
+            m_target->outfile()->close(ec);
             if (ec)
             {
-                spdlog::error("Could not close file: {}", target->outfile()->path().string());
+                spdlog::error("Could not close file: {}", m_target->outfile()->path().string());
             }
         }
+
+        m_headercb_interrupt_reason.clear();
     }
 
     void Target::reset_file(TransferStatus status)
     {
-        if (target->outfile() && status == TransferStatus::kSUCCESSFUL)
+        if (m_target->outfile() && status == TransferStatus::kSUCCESSFUL)
         {
             reset();
 
             std::error_code ec;
-            fs::rename(temp_file, target->filename(), ec);
+            fs::rename(m_temp_file, m_target->filename(), ec);
 
-            if (!ec && ctx.preserve_filetime)
+            if (!ec && m_ctx.preserve_filetime)
             {
-                auto remote_filetime = curl_handle->getinfo<curl_off_t>(CURLINFO_FILETIME_T);
+                auto remote_filetime = m_curl_handle->getinfo<curl_off_t>(CURLINFO_FILETIME_T);
                 if (!remote_filetime || remote_filetime.value() < 0)
                     spdlog::debug("Unable to get remote time of retrieved document");
 
                 if (remote_filetime.value() >= 0)
                 {
                     fs::file_time_type tp(std::chrono::seconds(remote_filetime.value()));
-                    fs::last_write_time(target->filename(), tp, ec);
+                    fs::last_write_time(m_target->filename(), tp, ec);
                 }
             }
         }
@@ -73,8 +75,8 @@ namespace powerloader
         else if (status == TransferStatus::kERROR)
         {
             reset();
-            spdlog::error("Removing file {}", temp_file.string());
-            fs::remove(temp_file);
+            spdlog::error("Removing file {}", m_temp_file.string());
+            fs::remove(m_temp_file);
         }
     }
 
@@ -83,17 +85,16 @@ namespace powerloader
         reset_file(status);
 
         CbReturnCode rc = CbReturnCode::kOK;
-        if (target->end_callback())
+        if (m_target->end_callback())
         {
-            if (curl_handle)
+            if (m_curl_handle)
             {
-                response.fill_values(*curl_handle);
+                m_response.fill_values(*m_curl_handle);
             }
-            rc = target->end_callback()(status, response);
+            rc = m_target->end_callback()(status, m_response);
 
             if (rc == CbReturnCode::kERROR)
             {
-                callback_return_code = CbReturnCode::kERROR;
                 spdlog::error("End-Callback returned an error");
             }
         }
@@ -105,56 +106,60 @@ namespace powerloader
         std::ptrdiff_t offset = 0;
         std::error_code ec;
 
-        if (!target->outfile() || !target->outfile()->open())
+        if (!m_target->outfile() || !m_target->outfile()->open())
             return true;
 
-        if (original_offset >= 0)
-            offset = original_offset;
+        if (m_original_offset >= 0)
+            offset = m_original_offset;
 
-        target->outfile()->truncate(offset, ec);
+        m_target->outfile()->truncate(offset, ec);
         if (ec)
         {
             throw std::runtime_error("Could not truncate file");
         }
 
-        target->outfile()->seek(offset, SEEK_SET);
+        m_target->outfile()->seek(offset, SEEK_SET);
         return true;
     }
 
     void Target::open_target_file()
     {
         // Use supplied filename
-        fs::path fn = target->filename();
-        temp_file = fn.replace_extension(fn.extension().string() + PARTEXT);
-        spdlog::info("Opening file {}", temp_file.string());
+        fs::path fn = m_target->filename();
+        m_temp_file = fn.replace_extension(fn.extension().string() + PARTEXT);
+        spdlog::info("Opening file {}", m_temp_file.string());
 
-        const auto open_mode = fs::exists(temp_file) && this->resume ? FileIO::append_update_binary
-                                                                     : FileIO::write_update_binary;
+        const auto open_mode = fs::exists(m_temp_file) && m_resume
+                                   ? FileIO::append_update_binary
+                                   : FileIO::write_update_binary;
 
         std::error_code ec;
-        target->set_outfile(std::make_unique<FileIO>(temp_file, open_mode, ec));
+        m_target->set_outfile(std::make_unique<FileIO>(m_temp_file, open_mode, ec));
 
         if (ec)
         {
             throw std::system_error(ec);
         }
+
+        m_writecb_received = 0;
+        m_writecb_required_range_written = false;
     }
 
 #ifdef WITH_ZCHUNK
     /* Fail if dl_ctx->fail_no_ranges is set and we get a 200 response */
     std::size_t zckheadercb(char* buffer, std::size_t size, std::size_t nitems, Target* self)
     {
-        assert(self && self->target);
+        assert(self && self->m_target);
         long code = -1;
-        curl_easy_getinfo(self->curl_handle->ptr(), CURLINFO_RESPONSE_CODE, &code);
+        curl_easy_getinfo(self->m_curl_handle->ptr(), CURLINFO_RESPONSE_CODE, &code);
         if (code == 200)
         {
             spdlog::info("Too many ranges were attempted in one download");
-            self->range_fail = 1;
+            self->m_range_fail = 1;
             return 0;
         }
 
-        return zck_header_cb(buffer, size, nitems, self->target->zck().zck_dl);
+        return zck_header_cb(buffer, size, nitems, self->m_target->zck().zck_dl);
     }
 #endif  // WITH_ZCHUNK
 
@@ -167,7 +172,7 @@ namespace powerloader
 
         size_t ret = size * nitems;
         Target* target = self;
-        HeaderCbState state = self->headercb_state;
+        HeaderCbState state = self->m_headercb_state;
 
         // TODO get rid of this?
         if (state == HeaderCbState::kDONE || state == HeaderCbState::kINTERRUPTED)
@@ -177,8 +182,8 @@ namespace powerloader
         }
 
 #ifdef WITH_ZCHUNK
-        if (target->target->is_zchunck() && !target->range_fail && target->mirror
-            && target->mirror->protocol() == Protocol::kHTTP)
+        if (target->target().is_zchunck() && !target->m_range_fail && target->m_mirror
+            && target->m_mirror->protocol() == Protocol::kHTTP)
             return zckheadercb(buffer, size, nitems, self);
 #endif /* WITH_ZCHUNK */
 
@@ -186,13 +191,13 @@ namespace powerloader
 
         if (state == HeaderCbState::kDEFAULT)
         {
-            if (target->protocol == Protocol::kHTTP && starts_with(header, "HTTP/"))
+            if (target->m_protocol == Protocol::kHTTP && starts_with(header, "HTTP/"))
             {
                 if (contains(header, "200")
                     || (contains(header, "206") && !contains(header, "connection established")))
                 {
                     spdlog::info("Header state OK! {}", header);
-                    target->headercb_state = HeaderCbState::kHTTP_STATE_OK;
+                    target->m_headercb_state = HeaderCbState::kHTTP_STATE_OK;
                 }
                 else
                 {
@@ -256,19 +261,19 @@ namespace powerloader
                 value = header.substr(colon_idx, header.size() - colon_idx - 2);
                 // http headers are case insensitive!
                 std::string lkey = to_lower(key);
-                target->response.headers[lkey] = value;
+                target->m_response.headers[lkey] = value;
 
-                if (target->target->expected_size() > 0 && lkey == "content-length")
+                if (target->target().expected_size() > 0 && lkey == "content-length")
                 {
                     ptrdiff_t content_length = std::stoll(std::string(value));
                     spdlog::info("Server returned Content-Length: {}", content_length);
-                    if (content_length > 0 && content_length != target->target->expected_size())
+                    if (content_length > 0 && content_length != target->target().expected_size())
                     {
-                        target->headercb_state = HeaderCbState::kINTERRUPTED;
-                        target->headercb_interrupt_reason = fmt::format(
+                        target->m_headercb_state = HeaderCbState::kINTERRUPTED;
+                        target->m_headercb_interrupt_reason = fmt::format(
                             "Server reports Content-Length: {} but expected size is: {}",
                             content_length,
-                            target->target->expected_size());
+                            target->target().expected_size());
 
                         // Return error value
                         ret++;
@@ -276,7 +281,7 @@ namespace powerloader
                     else
                     {
                         // TODO what when we also want ETag etc.?
-                        target->headercb_state = HeaderCbState::kDONE;
+                        target->m_headercb_state = HeaderCbState::kDONE;
                     }
                 }
             }
@@ -288,20 +293,20 @@ namespace powerloader
 #ifdef WITH_ZCHUNK
     std::size_t zckwritecb(char* buffer, size_t size, size_t nitems, Target* self)
     {
-        if (self->zck_state == ZckState::kHEADER)
+        if (self->m_zck_state == ZckState::kHEADER)
         {
             spdlog::info("zck: Writing header");
-            return zck_write_zck_header_cb(buffer, size, nitems, self->target->zck().zck_dl);
+            return zck_write_zck_header_cb(buffer, size, nitems, self->m_target->zck().zck_dl);
         }
-        else if (self->zck_state == ZckState::kHEADER_LEAD)
+        else if (self->m_zck_state == ZckState::kHEADER_LEAD)
         {
             spdlog::info("zck: Writing lead");
-            return self->target->outfile()->write(buffer, size, nitems);
+            return self->m_target->outfile()->write(buffer, size, nitems);
         }
         else
         {
             spdlog::info("zck: Writing body");
-            return zck_write_chunk_cb(buffer, size, nitems, self->target->zck().zck_dl);
+            return zck_write_chunk_cb(buffer, size, nitems, self->m_target->zck().zck_dl);
         }
     }
 #endif
@@ -316,8 +321,8 @@ namespace powerloader
         std::size_t cur_written_expected = nitems, cur_written;
 
 #ifdef WITH_ZCHUNK
-        if (self->target->is_zchunck() && !self->range_fail && self->mirror
-            && self->mirror->protocol() == Protocol::kHTTP)
+        if (self->m_target->is_zchunck() && !self->m_range_fail && self->m_mirror
+            && self->m_mirror->protocol() == Protocol::kHTTP)
         {
             return zckwritecb(buffer, size, nitems, self);
         }
@@ -325,34 +330,34 @@ namespace powerloader
 
         // Total number of bytes from curl
         const std::size_t all = size * nitems;
-        const std::size_t range_start = self->target->byterange_start();
-        const std::size_t range_end = self->target->byterange_end();
+        const std::size_t range_start = self->m_target->byterange_start();
+        const std::size_t range_end = self->m_target->byterange_end();
 
         if (range_start <= 0 && range_end <= 0)
         {
             // Write everything curl gives us
-            self->writecb_received += all;
-            return self->target->outfile()->write(buffer, size, nitems);
+            self->m_writecb_received += all;
+            return self->m_target->outfile()->write(buffer, size, nitems);
         }
 
         // Deal with situation when user wants only specific byte range of the
         // target file, and write only the range.
-        std::size_t cur_range_start = self->writecb_received;
+        std::size_t cur_range_start = self->m_writecb_received;
         std::size_t cur_range_end = cur_range_start + all;
 
-        self->writecb_received += all;
+        self->m_writecb_received += all;
 
-        if (self->target->byterange_start() > 0)
+        if (self->m_target->byterange_start() > 0)
         {
             // If byterangestart is specified, then CURLOPT_RESUME_FROM_LARGE
             // is used by default
-            cur_range_start += self->target->byterange_start();
-            cur_range_end += self->target->byterange_start();
+            cur_range_start += self->m_target->byterange_start();
+            cur_range_end += self->m_target->byterange_start();
         }
-        else if (self->original_offset > 0)
+        else if (self->m_original_offset > 0)
         {
-            cur_range_start += self->original_offset;
-            cur_range_end += self->original_offset;
+            cur_range_start += self->m_original_offset;
+            cur_range_end += self->m_original_offset;
         }
 
         if (cur_range_end < range_start)
@@ -364,7 +369,7 @@ namespace powerloader
             // The wanted byte range is over
             // Return zero that will lead to transfer abortion
             // with error code CURLE_WRITE_ERROR
-            self->writecb_required_range_written = true;
+            self->m_writecb_required_range_written = true;
             return 0;
         }
 
@@ -394,11 +399,11 @@ namespace powerloader
         }
 
         assert(nitems > 0);
-        cur_written = self->target->outfile()->write(buffer, size, nitems);
+        cur_written = self->m_target->outfile()->write(buffer, size, nitems);
 
         if (cur_written != nitems)
         {
-            spdlog::error("Writing file {}: {}", self->temp_file.string(), strerror(errno));
+            spdlog::error("Writing file {}: {}", self->m_temp_file.string(), strerror(errno));
             // There was an error
             return 0;
         }
@@ -416,27 +421,27 @@ namespace powerloader
         int ret = 0;
 
         assert(target);
-        assert(target->target);
+        assert(target->m_target);
 
-        if (target->state != DownloadState::kRUNNING)
+        if (target->m_state != DownloadState::kRUNNING)
         {
             return ret;
         }
 
-        if (!target->target->progress_callback())
+        if (!target->m_target->progress_callback())
         {
             return ret;
         }
 
 #ifdef WITH_ZCHUNK
-        if (target->target->is_zchunck())
+        if (target->m_target->is_zchunck())
         {
-            total_to_download = target->target->zck().total_to_download;
-            now_downloaded = now_downloaded + target->target->zck().downloaded;
+            total_to_download = target->m_target->zck().total_to_download;
+            now_downloaded = now_downloaded + target->m_target->zck().downloaded;
         }
 #endif /* WITH_ZCHUNK */
 
-        ret = target->target->progress_callback()(total_to_download, now_downloaded);
+        ret = target->m_target->progress_callback()(total_to_download, now_downloaded);
 
         // target->cb_return_code = ret;
 
@@ -445,14 +450,14 @@ namespace powerloader
 
     bool Target::check_filesize()
     {
-        if (target->expected_size() > 0)
+        if (m_target->expected_size() > 0)
         {
-            if (fs::file_size(temp_file) != static_cast<std::size_t>(target->expected_size()))
+            if (fs::file_size(m_temp_file) != m_target->expected_size())
             {
                 spdlog::error("Filesize of {} ({}) does not match expected filesize ({}).",
-                              temp_file.string(),
-                              fs::file_size(temp_file),
-                              target->expected_size());
+                              m_temp_file.string(),
+                              fs::file_size(m_temp_file),
+                              m_target->expected_size());
                 return false;
             }
         }
@@ -461,16 +466,433 @@ namespace powerloader
 
     bool Target::check_checksums()
     {
-        if (!ctx.validate_checksum)
+        if (!m_ctx.validate_checksum)
         {
             return true;
         }
 
-        if (target->checksums().empty())
+        if (m_target->checksums().empty())
         {
             return true;
         }
 
-        return target->validate_checksum(temp_file);
+        return m_target->validate_checksum(m_temp_file);
     }
+
+    void Target::change_mirror(std::shared_ptr<Mirror> mirror)
+    {
+        m_mirror = std::move(mirror);
+    }
+
+    CbReturnCode Target::set_failed(DownloaderError error)
+    {
+        m_state = DownloadState::kFAILED;
+        m_target->set_error(std::move(error));
+
+        return call_end_callback(TransferStatus::kERROR);
+    }
+
+    void Target::check_if_already_finished()
+    {
+        if (m_target->already_downloaded())
+        {
+            spdlog::info("Found already downloaded file!");
+            call_end_callback(TransferStatus::kALREADYEXISTS);
+            m_state = DownloadState::kFINISHED;
+        }
+    }
+
+    void Target::set_to_max_speed()
+    {
+        assert(m_curl_handle);
+        assert(m_ctx.max_speed_limit > 0);
+        m_curl_handle->setopt(CURLOPT_MAX_RECV_SPEED_LARGE,
+                                            static_cast<curl_off_t>(m_ctx.max_speed_limit));
+    }
+
+    void Target::reset_response()
+    {
+        m_response = {};
+    }
+
+    void Target::prepare_for_transfer(CURLM* multi_handle, const std::string& full_url, Protocol protocol)
+    {
+        // Prepare CURL easy handle
+        m_curl_handle.reset(new CURLHandle(m_ctx));
+        CURLHandle& h = *(m_curl_handle);
+
+        if (m_mirror && m_mirror->needs_preparation(this))
+        {
+            m_mirror->prepare(m_target->path(), h);
+            m_state = DownloadState::kPREPARATION;
+
+            CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h);
+            return;
+        }
+
+        // Set URL
+        h.url(full_url);
+
+        // Prepare FILE
+#ifdef WITH_ZCHUNK
+        if (!m_target->is_zchunck())
+        {
+#endif
+            this->open_target_file();
+#ifdef WITH_ZCHUNK
+        }
+        // If file is zchunk, prep it
+        if (m_target->is_zchunck())
+        {
+            if (!m_target->outfile())
+            {
+                spdlog::info("zck: opening file {}", this->temp_file().string());
+                this->open_target_file();
+            }
+
+            if (!check_zck(*this))
+            {
+                spdlog::error("Unable to initialize zchunk file!");
+                this->set_failed(DownloaderError{
+                    ErrorLevel::FATAL, ErrorCode::PD_ZCK, "Unable to initialize zchunk file" });
+            }
+
+            // If zchunk is finished, we're done, so move to next target
+            if (m_zck_state == ZckState::kFINISHED)
+            {
+                spdlog::info("Target fully downloaded: {}", m_target->path());
+                m_state = DownloadState::kFINISHED;
+                reset();
+                call_end_callback(TransferStatus::kSUCCESSFUL); // TODO: do something with the result?
+            }
+        }
+#endif /* WITH_ZCHUNK */
+
+        if (m_resume && m_resume_count >= m_ctx.max_resume_count)
+        {
+            m_resume = false;
+            spdlog::info("Download resume ignored, maximal number of attempts has been reached");
+        }
+
+        // Resume - set offset to resume incomplete download
+        if (m_resume)
+        {
+            m_resume_count++;
+            if (m_original_offset == -1)
+            {
+                // Determine offset
+                m_target->outfile()->seek(0L, SEEK_END);
+                std::ptrdiff_t determined_offset = m_target->outfile()->tell();
+
+                if (determined_offset == -1)
+                {
+                    // An error while determining offset => download the whole file again
+                    determined_offset = 0;
+                }
+                m_original_offset = determined_offset;
+            }
+
+            curl_off_t used_offset = m_original_offset;
+
+            spdlog::info("Trying to resume from offset {}", used_offset);
+            h.setopt(CURLOPT_RESUME_FROM_LARGE, used_offset);
+        }
+
+        if (m_target->byterange_start() > 0)
+        {
+            assert(!m_target->resume() && m_target->range().empty());
+            h.setopt(CURLOPT_RESUME_FROM_LARGE, (curl_off_t) m_target->byterange_start());
+        }
+
+        // Set range if user specified one
+        if (!m_target->range().empty())
+        {
+            assert(!m_target->resume() && !m_target->byterange_start());
+            h.setopt(CURLOPT_RANGE, m_target->range());
+        }
+
+        // Prepare progress callback
+        if (m_target->progress_callback())
+        {
+            h.setopt(CURLOPT_XFERINFOFUNCTION, &Target::progress_callback);
+            h.setopt(CURLOPT_NOPROGRESS, 0);
+            h.setopt(CURLOPT_XFERINFODATA, this);
+        }
+
+        // Prepare header callback
+        h.setopt(CURLOPT_HEADERFUNCTION, &Target::header_callback);
+        h.setopt(CURLOPT_HEADERDATA, this);
+
+        // Prepare write callback
+        h.setopt(CURLOPT_WRITEFUNCTION, &Target::write_callback);
+        h.setopt(CURLOPT_WRITEDATA, this);
+
+        // Set extra HTTP headers
+        if (this->mirror())
+        {
+            h.add_headers(this->mirror()->get_auth_headers(m_target->path()));
+        }
+
+        // accept default curl supported encodings
+        h.accept_encoding();
+        h.add_headers(m_ctx.additional_httpheaders);
+
+        if (m_target->no_cache())
+        {
+            // Add headers that tell proxy to serve us fresh data
+            h.add_header("Cache-Control: no-cache");
+            h.add_header("Pragma: no-cache");
+        }
+        else
+        {
+            m_target->add_handle_options(h);
+        }
+
+        // Add the new handle to the curl multi handle
+        CURL* handle = h;
+        CURLMcode cm_rc = curl_multi_add_handle(multi_handle, handle);
+        assert(cm_rc == CURLM_OK);
+
+        // Set the state of transfer as running
+        m_state = DownloadState::kRUNNING;
+
+        // Increase running transfers counter for mirror
+        if (m_mirror)
+        {
+            m_mirror->increase_running_transfers();
+        }
+
+        // Set the state of header callback for this transfer
+        m_headercb_state = HeaderCbState::kDEFAULT;
+        m_headercb_interrupt_reason.clear();
+
+        // Set protocol of the target
+        m_protocol = protocol;
+    }
+
+    tl::expected<void, DownloaderError> Target::finish_transfer(const std::string& effective_url)
+    {
+
+#ifdef WITH_ZCHUNK
+        if (m_target->is_zchunck())
+        {
+            if (m_zck_state == ZckState::kHEADER_LEAD)
+            {
+                if (!zck_read_lead(*this))
+                    return {};
+            }
+            else if (m_zck_state == ZckState::kHEADER)
+            {
+                if (m_mirror->stats().max_ranges > 0
+                    && m_mirror->protocol() == Protocol::kHTTP
+                    && !zck_valid_header(*this))
+                {
+                    return {};
+                }
+            }
+            else if (m_zck_state == ZckState::kBODY)
+            {
+                if (m_mirror->stats().max_ranges > 0
+                    && m_mirror->protocol() == Protocol::kHTTP)
+                {
+                    zckCtx* zck = zck_dl_get_zck(m_target->zck().zck_dl);
+                    if (zck == nullptr)
+                    {
+                        spdlog::error("Unable to get zchunk file from download context");
+                        return tl::unexpected(
+                            DownloaderError{ ErrorLevel::SERIOUS,
+                                             ErrorCode::PD_ZCK,
+                                             "Unable to get zchunk file from download context" });
+                    }
+                    if (zck_failed_chunks(zck) == 0 && zck_missing_chunks(zck) == 0)
+                    {
+                        m_zck_state = ZckState::kFINISHED;
+                    }
+                }
+                else
+                {
+                    m_zck_state = ZckState::kFINISHED;
+                }
+            }
+
+            if (m_zck_state == ZckState::kFINISHED)
+            {
+                zckCtx* zck = zck_init_read(*this);
+                if (!zck)
+                    return {};
+                if (zck_validate_checksums(zck) < 1)
+                {
+                    zck_free(&zck); // TODO: add RAII to handle that
+                    spdlog::error("At least one of the zchunk checksums doesn't match in {}",
+                                  effective_url);
+
+                    return tl::unexpected(DownloaderError{
+                        ErrorLevel::SERIOUS,
+                        ErrorCode::PD_BADCHECKSUM,
+                        fmt::format("At least one of the zchunk checksums doesn't match in {}",
+                                    effective_url) });
+                }
+                zck_free(&zck); // TODO: check if it's a leak when not reached
+            }
+        }
+        else
+        {
+#endif
+            tl::expected<void, DownloaderError> result;
+
+            if (m_target->outfile())
+            {
+                // New file was downloaded
+                if (!check_filesize())
+                {
+                    result = tl::unexpected(DownloaderError{ ErrorLevel::SERIOUS,
+                                          ErrorCode::PD_BADCHECKSUM,
+                                          "Result file does not have expected filesize" });
+                }
+                if (!check_checksums())
+                {
+                    result = tl::unexpected(DownloaderError{ ErrorLevel::SERIOUS,
+                                          ErrorCode::PD_BADCHECKSUM,
+                                          "Result file does not have expected checksum" });
+                }
+            }
+
+            if (!result)
+            {
+                reset_file(TransferStatus::kERROR);
+                return result;
+            }
+
+#ifdef WITH_ZCHUNK
+        }
+#endif
+        return {};
+    }
+
+    void Target::flush_target_file()
+    {
+        if (m_target->outfile() && m_target->outfile()->open())
+        {
+            m_target->outfile()->flush();
+        }
+    }
+
+    void Target::complete_mirror_usage(bool was_success, const tl::expected<void, DownloaderError>& result)
+    {
+        // TODO check if we were preparing here?
+        if (m_mirror)
+        {
+            m_tried_mirrors.insert(m_mirror);
+            m_mirror->update_statistics(was_success);
+            if (m_ctx.adaptive_mirror_sorting)
+                sort_mirrors(m_mirrors,
+                             m_mirror,
+                             was_success,
+                             result ? false : result.error().is_serious());
+        }
+    }
+
+    bool Target::can_retry_transfer_with_fewer_connections() const
+    {
+        if (!m_mirror)
+            return false;
+
+        const auto mirror_stats = m_mirror->stats();
+        return m_mirror->has_running_transfers()
+               || (mirror_stats.successful_transfers > 0
+                   && mirror_stats.failed_transfers < mirror_stats.max_tried_parallel_connections);
+    }
+
+    void Target::lower_mirror_parallel_connections()
+    {
+        if (!m_mirror)
+            return;
+
+        if (m_mirror->has_running_transfers())
+        {
+            const auto mirror_stats = m_mirror->stats();
+            m_mirror->set_allowed_parallel_connections(mirror_stats.running_transfers);
+        }
+        else
+        {
+            m_mirror->set_allowed_parallel_connections(1);
+        }
+
+        // Give used mirror another chance
+        m_tried_mirrors.erase(m_mirror);
+    }
+
+    bool Target::set_retrying()
+    {
+        m_state = DownloadState::kWAITING;
+        m_retries++;
+
+#ifdef WITH_ZCHUNK
+        if (!m_target->is_zchunck()
+            || m_zck_state == ZckState::kHEADER)
+        {
+#endif
+            // Truncate file - remove downloaded garbage (error html page etc.)
+            if (!truncate_transfer_file())
+                return false;
+#ifdef WITH_ZCHUNK
+        }
+#endif
+
+        return true;
+    }
+
+
+    void Target::finalize_transfer(const std::string& effective_url)
+    {
+#ifdef WITH_ZCHUNK
+        if (m_target->is_zchunck()
+            && m_zck_state != ZckState::kFINISHED)
+        {
+            m_state = DownloadState::kWAITING;
+            if (m_mirror)
+                m_tried_mirrors.erase(m_mirror);
+        }
+        else
+        {
+#endif /* WITH_ZCHUNK */
+            if (m_state == DownloadState::kRUNNING)
+            {
+                m_state = DownloadState::kFINISHED;
+            }
+            else if (m_state == DownloadState::kPREPARATION)
+            {
+                m_state = DownloadState::kWAITING;
+            }
+
+            // Remove xattr that states that the file is being downloaded
+            // by librepo, because the file is now completely downloaded
+            // and the xattr is not needed (is is useful only for resuming)
+            // remove_librepo_xattr(target->target);
+
+            // For "mirror preparation" we need to call finalize_transfer here!
+            if (m_curl_handle)
+                m_curl_handle->finalize_transfer();
+
+            // only call the end callback if actually finished the download target
+            if (m_state == DownloadState::kFINISHED)
+            {
+                const CbReturnCode rc
+                    = call_end_callback(TransferStatus::kSUCCESSFUL);
+                if (rc == CbReturnCode::kERROR)
+                {
+                    throw fatal_download_error("Interrupted by error from end callback");
+                }
+            }
+#ifdef WITH_ZCHUNK
+        }
+#endif /* WITH_ZCHUNK */
+        if (m_mirror)
+        {
+            m_target->set_mirror_to_use(m_mirror);
+        }
+
+        m_target->set_effective_url(effective_url);
+    }
+
 }

--- a/src/zck.cpp
+++ b/src/zck.cpp
@@ -35,11 +35,9 @@ namespace powerloader
         }
     }
 
-    zckCtx* init_zck_read(const Checksum& checksum,
-                          ptrdiff_t zck_header_size,
-                          int fd)
+    zckCtx* init_zck_read(const Checksum& checksum, ptrdiff_t zck_header_size, int fd)
     {
-        zckCtx* zck = zck_create(); // TODO: RAII this
+        zckCtx* zck = zck_create();  // TODO: RAII this
         if (!zck_init_adv_read(zck, fd))
         {
             zck_free(&zck);
@@ -73,9 +71,7 @@ namespace powerloader
         return zck;
     }
 
-    zckCtx* zck_init_read_base(const Checksum& checksum,
-                               std::ptrdiff_t zck_header_size,
-                               int fd)
+    zckCtx* zck_init_read_base(const Checksum& checksum, std::ptrdiff_t zck_header_size, int fd)
     {
         lseek(fd, 0, SEEK_SET);
         zckCtx* zck = init_zck_read(checksum, zck_header_size, fd);
@@ -97,9 +93,7 @@ namespace powerloader
         return zck;
     }
 
-    bool zck_valid_header_base(const Checksum& checksum,
-                               std::ptrdiff_t zck_header_size,
-                               int fd)
+    bool zck_valid_header_base(const Checksum& checksum, std::ptrdiff_t zck_header_size, int fd)
     {
         lseek(fd, 0, SEEK_SET);
         zckCtx* zck = init_zck_read(checksum, zck_header_size, fd);
@@ -344,7 +338,8 @@ namespace powerloader
             if (zck_get_chunk_valid(idx) != 1)
             {
                 // Estimate of multipart overhead
-                target.target().zck().total_to_download += zck_get_chunk_comp_size(idx) + 92; // TODO: name magic constant
+                target.target().zck().total_to_download
+                    += zck_get_chunk_comp_size(idx) + 92;  // TODO: name magic constant
             }
         }
         target.set_zck_state(ZckState::kBODY);
@@ -375,8 +370,8 @@ namespace powerloader
         spdlog::info("Chunks that still need to be downloaded: {}", zck_missing_chunks(zck));
 
         zck_dl_reset(target.target().zck().zck_dl);
-        zckRange* range
-            = zck_get_missing_range(zck, target.mirror() ? target.mirror()->stats().max_ranges : -1);
+        zckRange* range = zck_get_missing_range(
+            zck, target.mirror() ? target.mirror()->stats().max_ranges : -1);
         zckRange* old_range = zck_dl_get_range(target.target().zck().zck_dl);
         if (old_range)
         {
@@ -458,8 +453,9 @@ namespace powerloader
             {
                 throw zchunk_error(zck_get_error(nullptr));
             }
-            target.set_zck_state(target.target().zck().zck_header_size == -1 ? ZckState::kHEADER_LEAD
-                                                                            : ZckState::kHEADER_CK);
+            target.set_zck_state(target.target().zck().zck_header_size == -1
+                                     ? ZckState::kHEADER_LEAD
+                                     : ZckState::kHEADER_CK);
         }
 
         /* Reset range fail flag */

--- a/src/zck.hpp
+++ b/src/zck.hpp
@@ -50,19 +50,13 @@ namespace powerloader
     POWERLOADER_API ChecksumType checksum_type_from_zck_hash(zck_hash hash_type);
 
     POWERLOADER_API
-    zckCtx* init_zck_read(const Checksum& chksum,
-                          ptrdiff_t zck_header_size,
-                          int fd);
+    zckCtx* init_zck_read(const Checksum& chksum, ptrdiff_t zck_header_size, int fd);
 
     POWERLOADER_API
-    zckCtx* zck_init_read_base(const Checksum& chksum,
-                               std::ptrdiff_t zck_header_size,
-                               int fd);
+    zckCtx* zck_init_read_base(const Checksum& chksum, std::ptrdiff_t zck_header_size, int fd);
 
     POWERLOADER_API
-    bool zck_valid_header_base(const Checksum& chksum,
-                               std::ptrdiff_t zck_header_size,
-                               int fd);
+    bool zck_valid_header_base(const Checksum& chksum, std::ptrdiff_t zck_header_size, int fd);
 
     POWERLOADER_API zckCtx* zck_init_read(const DownloadTarget& target, int fd);
     POWERLOADER_API zckCtx* zck_init_read(const Target& target);

--- a/src/zck.hpp
+++ b/src/zck.hpp
@@ -20,10 +20,9 @@ extern "C"
 
 namespace powerloader
 {
-    class zchunk_error : public std::runtime_error
+    struct zchunk_error : public std::runtime_error
     {
-    public:
-        inline zchunk_error(const std::string& what = "zchunk error")
+        zchunk_error(const std::string& what = "zchunk error")
             : std::runtime_error(what)
         {
         }
@@ -51,42 +50,42 @@ namespace powerloader
     POWERLOADER_API ChecksumType checksum_type_from_zck_hash(zck_hash hash_type);
 
     POWERLOADER_API
-    zckCtx* init_zck_read(const std::unique_ptr<Checksum>& chksum,
+    zckCtx* init_zck_read(const Checksum& chksum,
                           ptrdiff_t zck_header_size,
                           int fd);
 
     POWERLOADER_API
-    zckCtx* zck_init_read_base(const std::unique_ptr<Checksum>& chksum,
+    zckCtx* zck_init_read_base(const Checksum& chksum,
                                std::ptrdiff_t zck_header_size,
                                int fd);
 
     POWERLOADER_API
-    bool zck_valid_header_base(const std::unique_ptr<Checksum>& chksum,
+    bool zck_valid_header_base(const Checksum& chksum,
                                std::ptrdiff_t zck_header_size,
                                int fd);
 
-    POWERLOADER_API zckCtx* zck_init_read(const std::shared_ptr<DownloadTarget>& target, int fd);
-    POWERLOADER_API zckCtx* zck_init_read(Target* target);
+    POWERLOADER_API zckCtx* zck_init_read(const DownloadTarget& target, int fd);
+    POWERLOADER_API zckCtx* zck_init_read(const Target& target);
 
-    POWERLOADER_API bool zck_valid_header(const std::shared_ptr<DownloadTarget>& target, int fd);
-    POWERLOADER_API bool zck_valid_header(Target* target);
+    POWERLOADER_API bool zck_valid_header(const DownloadTarget& target, int fd);
+    POWERLOADER_API bool zck_valid_header(const Target& target);
 
-    POWERLOADER_API bool zck_clear_header(Target* target);
-    POWERLOADER_API bool zck_read_lead(Target* target);
-    POWERLOADER_API std::vector<fs::path> get_recursive_files(fs::path dir,
+    POWERLOADER_API bool zck_clear_header(Target& target);
+    POWERLOADER_API bool zck_read_lead(Target& target);
+    POWERLOADER_API std::vector<fs::path> get_recursive_files(const fs::path& dir,
                                                               const std::string& suffix);
 
     // TODO replace...
     POWERLOADER_API int lr_copy_content(int source, int dest);
 
-    POWERLOADER_API bool find_local_zck_header(Target* target);
+    POWERLOADER_API bool find_local_zck_header(Target& target);
 
-    POWERLOADER_API bool prep_zck_header(Target* target);
+    POWERLOADER_API bool prep_zck_header(Target& target);
 
-    POWERLOADER_API bool find_local_zck_chunks(Target* target);
+    POWERLOADER_API bool find_local_zck_chunks(Target& target);
 
-    POWERLOADER_API bool prepare_zck_body(Target* target);
-    POWERLOADER_API bool check_zck(Target* target);
+    POWERLOADER_API bool prepare_zck_body(Target& target);
+    POWERLOADER_API bool check_zck(Target& target);
 
     POWERLOADER_API bool zck_extract(const fs::path& source, const fs::path& dst, bool validate);
 }


### PR DESCRIPTION
Limiting direct access to the members of `Target` lead to a lot of discoveries about the organisation of `Downloader` and `zck` data and functions, which is why this commit is quite bigger than initially expected. 😬 
Some code have been moved from `Downloader` to `Target` member functions as they are mainly manipulating the state of `Target` without much changes to `Downloader`, which basically is a sign that it's code related to `Target`.

This is really just side effects of trying to make the `Target` interface more contained. Because a lot of other code was manipulating it's internals directly, it ended up touching a lot of code.
Where possible I tried to keep the order and meaning of the code when I had to move it around.

More info and discoveries (to help lead the related PRs that will come soon):

- There is *multiple accidental data structures* hidden in `Target`, most related to different aspects of a download process.
- This makes difficult to follow which states `Target` can take and when (there is also a lot of redundancy in how `Target`'s state is changed).
- `Target`, `Downloader` and `zck` data/functions are intertwined in a way that suggests there is a several separation necessary (but I didn't proceed where I didn't need to, for now) - basically this lacks "separation of concerns" and should be improved.
- Both `Target` and `zck` seems to be internal details of `Downloader`'s mechanisms, which is fine, but it also means we should not expose them as public interfaces (I think, or at least not completely).
- `Downloader::check_msg` seems to have at least 3 transfer error flags that might be contradictory; this makes difficult to understand which flag means what kind of error.


All this will probably participate to complications in evolving `libpowerloader`, but we are in a good position and time to improve the situation. :)

