### PR TITLE
Static builds now links with static deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI shared
 on:
   push:
     branches:
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        build_type: [static_build, shared_build]
 
     name: test
     steps:
@@ -28,18 +27,6 @@ jobs:
         uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment.yml
-
-      - name: static build option
-        if: matrix.build_type == 'static_build'
-        run: |
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DBUILD_STATIC=ON"
-          echo "CMAKE_EXTRA_ARGS=$CMAKE_EXTRA_ARGS" >> $GITHUB_ENV
-
-      - name: shared build option
-        if: matrix.build_type == 'shared_build'
-        run: |
-          CMAKE_EXTRA_ARGS="$CMAKE_EXTRA_ARGS -DBUILD_SHARED=ON"
-          echo "CMAKE_EXTRA_ARGS=$CMAKE_EXTRA_ARGS" >> $GITHUB_ENV
 
       - name: build powerloader
         if: runner.os != 'Windows'
@@ -51,9 +38,9 @@ jobs:
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
             -DWITH_ZCHUNK=$USE_ZCHUNK \
+            -DBUILD_SHARED=ON \
             -DENABLE_TESTS=ON \
-            -DBUILD_EXE=ON \
-            ${{ env.CMAKE_EXTRA_ARGS }}
+            -DBUILD_EXE=ON
           ninja
 
       - name: run powerloader tests
@@ -75,8 +62,8 @@ jobs:
           cmake .. -DCMAKE_PREFIX_PATH=%CONDA_PREFIX%\Library ^
                    -DENABLE_TESTS=ON ^
                    -DWITH_ZCHUNK=OFF ^
+                   -DBUILD_SHARED=ON ^
                    -DBUILD_EXE=ON ^
-                   ${{ env.CMAKE_EXTRA_ARGS }} ^
                    -G "Ninja"
           ninja
           ninja test

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,4 +1,4 @@
-name: Fully static build
+name: CI static
 
 on:
   push:
@@ -13,7 +13,7 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  powerloader_full_static:
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,15 +34,15 @@ jobs:
             -GNinja \
             -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX \
             -DWITH_ZCHUNK=$USE_ZCHUNK \
-            -DBUILD_STATIC_DEPS=ON \
-            -DBUILD_EXE=OFF
+            -DBUILD_STATIC=ON \
+            -DBUILD_EXE=ON
           ninja
       - name: run powerloader tests
         run: |
           cd build
           ninja test
 
-  powerloader_full_static_win:
+  test_win:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v3
@@ -89,8 +89,8 @@ jobs:
             -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
             -D CMAKE_PREFIX_PATH="%VCPKG_ROOT%\installed\x64-windows-static;%CMAKE_PREFIX_PATH%" ^
             -D WITH_ZCHUNK=ON ^
-            -D BUILD_STATIC_DEPS=ON  ^
-            -D BUILD_EXE=OFF ^
+            -D BUILD_STATIC=ON  ^
+            -D BUILD_EXE=ON ^
             -G "Ninja"
           ninja
       - name: run powerloader test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,15 +53,12 @@ option(WITH_ZCHUNK "Enable zchunk" ON)
 option(DEV "Enable dev" OFF)
 option(BUILD_SHARED "Build shared powerloader library" OFF)
 option(BUILD_STATIC "Build static powerloader library" OFF)
-option(BUILD_STATIC_DEPS "Build static powerloader library with static linkage to its dependencies" OFF)
 option(BUILD_EXE "Build powerloader executable" OFF)
 option(WITH_ZSTD "Build powerloader with zstd" ON)
 
 # Test options
 option(ENABLE_TESTS "Enable tests" ON)
 option(ENABLE_PYTHON "Enable python bindings" OFF)
-
-
 
 if (WITH_ZCHUNK)
     find_library(ZCK_LIBRARY zck REQUIRED)
@@ -323,18 +320,13 @@ if (BUILD_STATIC)
     # On Windows, a static library should use a different output name
     # to avoid the conflict with the import library of a shared one.
     if (WIN32)
-        libpowerloader_create_target(libpowerloader-static STATIC SHARED libpowerloader_static)
+        libpowerloader_create_target(libpowerloader-static STATIC STATIC libpowerloader_static)
     else ()
-        libpowerloader_create_target(libpowerloader-static STATIC SHARED libpowerloader)
+        libpowerloader_create_target(libpowerloader-static STATIC STATIC libpowerloader)
     endif ()
 endif ()
 
-if (BUILD_STATIC_DEPS)
-    message(STATUS "Adding full-static libpowerloader target")
-    libpowerloader_create_target(libpowerloader-full-static STATIC STATIC libpowerloader_full_static)
-endif ()
-
-if (NOT (BUILD_SHARED OR BUILD_STATIC OR BUILD_STATIC_DEPS))
+if (NOT (BUILD_SHARED OR BUILD_STATIC))
     message(FATAL_ERROR "Select at least a build variant for libpowerloader")
 endif ()
 
@@ -345,8 +337,6 @@ if (BUILD_SHARED)
     set(powerloader_dependency libpowerloader)
 elseif (BUILD_STATIC)
     set(powerloader_dependency libpowerloader-static)
-else ()
-    set(powerloader_dependency libpowerloader-full-static)
 endif ()
 
 # powerloader executable
@@ -354,7 +344,7 @@ endif ()
 
 if (BUILD_EXE)
     add_executable(powerloader ${POWERLOADER_SOURCE_DIR}/cli/main.cpp)
-    if (WIN32 AND BUILD_STATIC_DEPS)
+    if (WIN32 AND BUILD_STATIC)
         set_target_properties(powerloader PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     endif()
 

--- a/environment-static-dev-win.yml
+++ b/environment-static-dev-win.yml
@@ -2,6 +2,7 @@ name: powerloader-dev
 channels:
   - conda-forge
 dependencies:
+  # libpowerloader-static
   - vs2019_win-64
   - ninja
   - vcpkg
@@ -10,5 +11,8 @@ dependencies:
   - spdlog
   - nlohmann_json
   - zchunk-static
+  # powerloader
+  - cli11
+  - yaml-cpp
   # Tests
   - doctest

--- a/environment-static-dev.yml
+++ b/environment-static-dev.yml
@@ -2,6 +2,7 @@ name: powerloader-dev
 channels:
   - conda-forge
 dependencies:
+  # libpowerloader-static
   - cmake
   - ninja
   - cxx-compiler
@@ -16,5 +17,8 @@ dependencies:
   - cpp-expected
   - spdlog
   - nlohmann_json
+  # powerloader
+  - cli11
+  - yaml-cpp
   # Tests
   - doctest

--- a/environment.yml
+++ b/environment.yml
@@ -2,21 +2,24 @@ name: powerloader
 channels:
 - conda-forge
 dependencies:
+  # libpowerloader
   - cmake
   - ninja
   - cxx-compiler
   - libcurl
   - openssl
   - nlohmann_json
-  - cli11
   - zchunk
   - spdlog
-  - doctest
+  - cpp-expected
+  # powerloader
+  - cli11
   - yaml-cpp
+  # Tests
+  - doctest
   - pytest
   - pyyaml
   - python
   - pybind11
   - requests
-  - cpp-expected
   - pytest-xprocess

--- a/powerloaderConfig.cmake.in
+++ b/powerloaderConfig.cmake.in
@@ -21,6 +21,10 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR};${CMAKE_MODULE_PATH}")
 
 @POWERLOADER_CONFIG_CODE@
 
+# TODO: when all the dependencies are packaged correclty,
+# find dep or dep-static depending on the available target
+# in @PROJECT_NAME@Targets.cmake
+
 include(CMakeFindDependencyMacro)
 find_dependency(CURL)
 find_dependency(OpenSSL)
@@ -30,11 +34,16 @@ find_dependency(tl-expected)
 find_dependency(spdlog)
 
 
-if(NOT TARGET libpowerloader)
+if(NOT TARGET libpowerloader AND NOT TARGET libpowerloader-static)
     include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
+
+    if (TARGET libpowerloader-static)
+        get_target_property(@PROJECT_NAME@_INCLUDE_DIR libpowerloader-static INTERFACE_INCLUDE_DIRECTORIES)
+        get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libpowerloader-static LOCATION)
 
     if (TARGET libpowerloader)
         get_target_property(@PROJECT_NAME@_INCLUDE_DIR libpowerloader INTERFACE_INCLUDE_DIRECTORIES)
         get_target_property(@PROJECT_NAME@_LIBRARY libpowerloader LOCATION)
     endif ()
+
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ set(TEST_SRCS
 )
 
 add_executable(test_powerloader ${TEST_SRCS})
-if (WIN32 AND BUILD_STATIC_DEPS)
+if (WIN32 AND BUILD_STATIC)
     set_target_properties(test_powerloader PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 


### PR DESCRIPTION
The `BUILD_STATIC_DEPS` option has been removed. The defualt for a static build is now ot link with its static dependencies. I didn't remove the ability to build a static build linking with dynamic depenencies in the macro for creating targets since we may need it in the future and it doe snot really simplify the code.