### PR TITLE
Wrap libcurl calls

### DIFF
--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -92,9 +92,6 @@ namespace powerloader
         Response perform();
         void finalize_transfer();
 
-        template <class T>
-        tl::expected<T, CURLcode> getinfo(CURLINFO option);
-
         bool handle_exists();
 
         CURLHandle& add_header(const std::string& header);
@@ -116,7 +113,11 @@ namespace powerloader
     private:
         void init_handle(const Context& ctx);
         void finalize_transfer(Response& response);
+
         CURL* handle();
+
+        template <class T>
+        tl::expected<T, CURLcode> getinfo(CURLINFO option);
 
         CURL* m_handle;
         curl_slist* p_headers = nullptr;

--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -95,8 +95,7 @@ namespace powerloader
         template <class T>
         tl::expected<T, CURLcode> getinfo(CURLINFO option);
 
-        // TODO: why do we need to expose these methods
-        CURL* handle();
+        bool handle_exists();
 
         CURLHandle& add_header(const std::string& header);
         CURLHandle& add_headers(const std::vector<std::string>& headers);
@@ -117,6 +116,7 @@ namespace powerloader
     private:
         void init_handle(const Context& ctx);
         void finalize_transfer(Response& response);
+        CURL* handle();
 
         CURL* m_handle;
         curl_slist* p_headers = nullptr;
@@ -124,6 +124,12 @@ namespace powerloader
 
         std::unique_ptr<Response> response;
         end_callback_type end_callback;
+
+        friend class CURLInterface;
+
+        friend void add_multipart_upload(CURLHandle& target,
+                     const std::vector<std::string>& files,
+                     const std::map<std::string, std::string>& extra_fields);
     };
 
     // TODO: restrict the possible implementations in the cpp file

--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -97,7 +97,6 @@ namespace powerloader
 
         // TODO: why do we need to expose these methods
         CURL* handle();
-        CURL* ptr() const;
 
         CURLHandle& add_header(const std::string& header);
         CURLHandle& add_headers(const std::vector<std::string>& headers);

--- a/include/powerloader/curl.hpp
+++ b/include/powerloader/curl.hpp
@@ -77,9 +77,6 @@ namespace powerloader
         nlohmann::json json() const;
     };
 
-    // TODO: rename this, try to not expose it
-    POWERLOADER_API CURL* get_handle(const Context& ctx);
-
     class POWERLOADER_API CURLHandle
     {
     public:
@@ -94,15 +91,12 @@ namespace powerloader
 
         Response perform();
         void finalize_transfer();
-        // TODO: should be private?
-        void finalize_transfer(Response& response);
 
         template <class T>
         tl::expected<T, CURLcode> getinfo(CURLINFO option);
 
-        // TODO: why do we need to expose these three methods
+        // TODO: why do we need to expose these methods
         CURL* handle();
-        operator CURL*();  // TODO: consider making this `explicit` or remove it
         CURL* ptr() const;
 
         CURLHandle& add_header(const std::string& header);
@@ -123,6 +117,7 @@ namespace powerloader
 
     private:
         void init_handle(const Context& ctx);
+        void finalize_transfer(Response& response);
 
         CURL* m_handle;
         curl_slist* p_headers = nullptr;

--- a/include/powerloader/download_target.hpp
+++ b/include/powerloader/download_target.hpp
@@ -13,7 +13,6 @@
 
 namespace powerloader
 {
-
     struct zck_target;
 
     struct POWERLOADER_API CacheControl
@@ -21,12 +20,6 @@ namespace powerloader
         std::string etag;
         std::string cache_control;
         std::string last_modified;
-    };
-
-    enum CompressionType
-    {
-        NONE,
-        ZSTD,
     };
 
     class POWERLOADER_API DownloadTarget
@@ -80,7 +73,7 @@ namespace powerloader
             m_error = std::move(err);
         }
 
-        /// Returns a DownloadError if there was a falure at download or none if no error was set so
+        /// Returns a DownloadError if there was a failure at download or none if no error was set so
         /// far.
         std::optional<DownloaderError> get_error() const noexcept
         {

--- a/include/powerloader/enums.hpp
+++ b/include/powerloader/enums.hpp
@@ -15,6 +15,22 @@ namespace powerloader
         // Want: S3, OCI
     };
 
+    enum CompressionType
+    {
+        NONE,
+        ZSTD,
+    };
+
+    enum class MirrorState
+    {
+        WAITING,
+        AUTHENTICATING,
+        READY,
+        RETRY_DELAY,
+        AUTHENTICATION_FAILED,
+        FAILED
+    };
+
     enum class DownloadState
     {
         // The target is waiting to be processed.
@@ -81,11 +97,114 @@ namespace powerloader
         kMD5
     };
 
+    /** Librepo return/error codes */
+    enum class ErrorCode
+    {
+        // everything is ok
+        PD_OK,
+        // bad function argument
+        PD_BADFUNCARG,
+        // bad argument of the option
+        PD_BADOPTARG,
+        // library doesn't know the option
+        PD_UNKNOWNOPT,
+        // cURL doesn't know the option. Too old curl version?
+        PD_CURLSETOPT,
+        // Result object is not clean
+        PD_ADYUSEDRESULT,
+        // Result doesn't contain all what is needed
+        PD_INCOMPLETERESULT,
+        // cannot duplicate curl handle
+        PD_CURLDUP,
+        // cURL error
+        PD_CURL,
+        // cURL multi handle error
+        PD_CURLM,
+        // HTTP or FTP returned status code which do not represent success
+        // (file doesn't exists, etc.)
+        PD_BADSTATUS,
+        // some error that should be temporary and next try could work
+        // (HTTP status codes 500, 502-504, operation timeout, ...)
+        PD_TEMPORARYERR,
+        // URL is not a local address
+        PD_NOTLOCAL,
+        // cannot create a directory in output dir (ady exists?)
+        PD_CANNOTCREATEDIR,
+        // input output error
+        PD_IO,
+        // bad mirrorlist/metalink file (metalink doesn't contain needed
+        // file, mirrorlist doesn't contain urls, ..)
+        PD_MIRRORS,
+        // bad checksum
+        PD_BADCHECKSUM,
+        // no usable URL found
+        PD_NOURL,
+        // cannot create tmp directory
+        PD_CANNOTCREATETMP,
+        // unknown type of checksum is needed for verification
+        PD_UNKNOWNCHECKSUM,
+        // bad URL specified
+        PD_BADURL,
+        // Download was interrupted by signal.
+        // Only if LRO_INTERRUPTIBLE option is enabled.
+        PD_INTERRUPTED,
+        // sigaction error
+        PD_SIGACTION,
+        // File ady exists and checksum is ok.*/
+        PD_ADYDOWNLOADED,
+        // The download wasn't or cannot be finished.
+        PD_UNFINISHED,
+        // select() call failed.
+        PD_SELECT,
+        // OpenSSL library related error.
+        PD_OPENSSL,
+        // Cannot allocate more memory
+        PD_MEMORY,
+        // Interrupted by user cb
+        PD_CBINTERRUPTED,
+        // File operation error (operation not permitted, filename too long, no memory available,
+        // bad file descriptor, ...)
+        PD_FILE,
+        // Zchunk error (error reading zchunk file, ...)
+        PD_ZCK,
+        // (xx) unknown error - sentinel of error codes enum
+        PD_UNKNOWNERROR,
+    };
+
+    enum ErrorLevel
+    {
+        INFO,
+        SERIOUS,
+        FATAL
+    };
+
     struct Checksum
     {
         ChecksumType type;
         std::string checksum;
     };
+
+    /** AS A REFERENCE */
+    // typedef enum {
+    //   CURLUE_OK,
+    //   CURLUE_BAD_HANDLE,          /* 1 */
+    //   CURLUE_BAD_PARTPOINTER,     /* 2 */
+    //   CURLUE_MALFORMED_INPUT,     /* 3 */
+    //   CURLUE_BAD_PORT_NUMBER,     /* 4 */
+    //   CURLUE_UNSUPPORTED_SCHEME,  /* 5 */
+    //   CURLUE_URLDECODE,           /* 6 */
+    //   CURLUE_OUT_OF_MEMORY,       /* 7 */
+    //   CURLUE_USER_NOT_ALLOWED,    /* 8 */
+    //   CURLUE_UNKNOWN_PART,        /* 9 */
+    //   CURLUE_NO_SCHEME,           /* 10 */
+    //   CURLUE_NO_USER,             /* 11 */
+    //   CURLUE_NO_PASSWORD,         /* 12 */
+    //   CURLUE_NO_OPTIONS,          /* 13 */
+    //   CURLUE_NO_HOST,             /* 14 */
+    //   CURLUE_NO_PORT,             /* 15 */
+    //   CURLUE_NO_QUERY,            /* 16 */
+    //   CURLUE_NO_FRAGMENT          /* 17 */
+    // } CURLUcode;
 }
 
 #endif

--- a/include/powerloader/errors.hpp
+++ b/include/powerloader/errors.hpp
@@ -2,91 +2,10 @@
 #define POWERLOADER_ERRORS_HPP
 
 #include <spdlog/spdlog.h>
+#include <powerloader/enums.hpp>
 
 namespace powerloader
 {
-    /** Librepo return/error codes
-     */
-    enum class ErrorCode
-    {
-        // everything is ok
-        PD_OK,
-        // bad function argument
-        PD_BADFUNCARG,
-        // bad argument of the option
-        PD_BADOPTARG,
-        // library doesn't know the option
-        PD_UNKNOWNOPT,
-        // cURL doesn't know the option. Too old curl version?
-        PD_CURLSETOPT,
-        // Result object is not clean
-        PD_ADYUSEDRESULT,
-        // Result doesn't contain all what is needed
-        PD_INCOMPLETERESULT,
-        // cannot duplicate curl handle
-        PD_CURLDUP,
-        // cURL error
-        PD_CURL,
-        // cURL multi handle error
-        PD_CURLM,
-        // HTTP or FTP returned status code which do not represent success
-        // (file doesn't exists, etc.)
-        PD_BADSTATUS,
-        // some error that should be temporary and next try could work
-        // (HTTP status codes 500, 502-504, operation timeout, ...)
-        PD_TEMPORARYERR,
-        // URL is not a local address
-        PD_NOTLOCAL,
-        // cannot create a directory in output dir (ady exists?)
-        PD_CANNOTCREATEDIR,
-        // input output error
-        PD_IO,
-        // bad mirrorlist/metalink file (metalink doesn't contain needed
-        // file, mirrorlist doesn't contain urls, ..)
-        PD_MIRRORS,
-        // bad checksum
-        PD_BADCHECKSUM,
-        // no usable URL found
-        PD_NOURL,
-        // cannot create tmp directory
-        PD_CANNOTCREATETMP,
-        // unknown type of checksum is needed for verification
-        PD_UNKNOWNCHECKSUM,
-        // bad URL specified
-        PD_BADURL,
-        // Download was interrupted by signal.
-        // Only if LRO_INTERRUPTIBLE option is enabled.
-        PD_INTERRUPTED,
-        // sigaction error
-        PD_SIGACTION,
-        // File ady exists and checksum is ok.*/
-        PD_ADYDOWNLOADED,
-        // The download wasn't or cannot be finished.
-        PD_UNFINISHED,
-        // select() call failed.
-        PD_SELECT,
-        // OpenSSL library related error.
-        PD_OPENSSL,
-        // Cannot allocate more memory
-        PD_MEMORY,
-        // Interrupted by user cb
-        PD_CBINTERRUPTED,
-        // File operation error (operation not permitted, filename too long, no memory available,
-        // bad file descriptor, ...)
-        PD_FILE,
-        // Zchunk error (error reading zchunk file, ...)
-        PD_ZCK,
-        // (xx) unknown error - sentinel of error codes enum
-        PD_UNKNOWNERROR,
-    };
-
-    enum ErrorLevel
-    {
-        INFO,
-        SERIOUS,
-        FATAL
-    };
-
     struct DownloaderError
     {
         ErrorLevel level;

--- a/include/powerloader/mirror.hpp
+++ b/include/powerloader/mirror.hpp
@@ -17,16 +17,6 @@ namespace powerloader
     class Target;
     class Context;
 
-    enum class MirrorState
-    {
-        WAITING,
-        AUTHENTICATING,
-        READY,
-        RETRY_DELAY,
-        AUTHENTICATION_FAILED,
-        FAILED
-    };
-
     struct MirrorStats
     {
         // Maximum number of allowed parallel connections to this mirror. -1 means no

--- a/include/powerloader/url.hpp
+++ b/include/powerloader/url.hpp
@@ -19,27 +19,6 @@ extern "C"
 
 #include <powerloader/export.hpp>
 
-// typedef enum {
-//   CURLUE_OK,
-//   CURLUE_BAD_HANDLE,          /* 1 */
-//   CURLUE_BAD_PARTPOINTER,     /* 2 */
-//   CURLUE_MALFORMED_INPUT,     /* 3 */
-//   CURLUE_BAD_PORT_NUMBER,     /* 4 */
-//   CURLUE_UNSUPPORTED_SCHEME,  /* 5 */
-//   CURLUE_URLDECODE,           /* 6 */
-//   CURLUE_OUT_OF_MEMORY,       /* 7 */
-//   CURLUE_USER_NOT_ALLOWED,    /* 8 */
-//   CURLUE_UNKNOWN_PART,        /* 9 */
-//   CURLUE_NO_SCHEME,           /* 10 */
-//   CURLUE_NO_USER,             /* 11 */
-//   CURLUE_NO_PASSWORD,         /* 12 */
-//   CURLUE_NO_OPTIONS,          /* 13 */
-//   CURLUE_NO_HOST,             /* 14 */
-//   CURLUE_NO_PORT,             /* 15 */
-//   CURLUE_NO_QUERY,            /* 16 */
-//   CURLUE_NO_FRAGMENT          /* 17 */
-// } CURLUcode;
-
 namespace powerloader
 {
     POWERLOADER_API bool has_scheme(const std::string& url);

--- a/include/powerloader/url.hpp
+++ b/include/powerloader/url.hpp
@@ -135,11 +135,6 @@ namespace powerloader
         }
     }  // namespace detail
 
-    inline std::string join_url()
-    {
-        return "";
-    }
-
     template <class S, class... Args>
     inline std::string join_url(const S& s, const Args&... args)
     {

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -382,11 +382,11 @@ namespace powerloader
     void Response::fill_values(CURLHandle& handle)
     {
         average_speed
-            = handle.getinfo<decltype(average_speed)>(CURLINFO_SPEED_DOWNLOAD_T).value_or(0);
-        http_status = handle.getinfo<decltype(http_status)>(CURLINFO_RESPONSE_CODE).value();
-        effective_url = handle.getinfo<decltype(effective_url)>(CURLINFO_EFFECTIVE_URL).value();
+            = CURLInterface::get_info_wrapped<decltype(average_speed)>(handle, CURLINFO_SPEED_DOWNLOAD_T).value_or(0);
+        http_status = CURLInterface::get_info_wrapped<decltype(http_status)>(handle, CURLINFO_RESPONSE_CODE).value();
+        effective_url = CURLInterface::get_info_wrapped<decltype(effective_url)>(handle, CURLINFO_EFFECTIVE_URL).value();
         downloaded_size
-            = handle.getinfo<decltype(downloaded_size)>(CURLINFO_SIZE_DOWNLOAD_T).value();
+            = CURLInterface::get_info_wrapped<decltype(downloaded_size)>(handle, CURLINFO_SIZE_DOWNLOAD_T).value();
     }
 
     std::optional<std::string> proxy_match(const proxy_map_type& proxies, const std::string& url)
@@ -482,5 +482,11 @@ namespace powerloader
     bool CURLInterface::handle_is_equal(CURLHandle* h, CURLMsg* msg)
     {
         return (h->handle() == msg->easy_handle);
+    }
+
+    template <class T>
+    tl::expected<T, CURLcode> CURLInterface::get_info_wrapped(CURLHandle& h, CURLINFO option)
+    {
+        return h.getinfo<T>(option);
     }
 }

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -225,11 +225,6 @@ namespace powerloader
         return m_handle;
     }
 
-    CURLHandle::operator CURL*()
-    {
-        return handle();
-    }
-
     CURL* CURLHandle::ptr() const
     {
         return m_handle;

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -225,10 +225,6 @@ namespace powerloader
         return m_handle;
     }
 
-    CURL* CURLHandle::ptr() const
-    {
-        return m_handle;
-    }
 
     CURLHandle& CURLHandle::add_header(const std::string& header)
     {

--- a/src/curl.cpp
+++ b/src/curl.cpp
@@ -225,6 +225,10 @@ namespace powerloader
         return m_handle;
     }
 
+    bool CURLHandle::handle_exists()
+    {
+        return (handle() != nullptr);
+    }
 
     CURLHandle& CURLHandle::add_header(const std::string& header)
     {
@@ -463,6 +467,20 @@ namespace powerloader
             curl_global_cleanup();
             is_curl_setup_alive = false;
         }
+    }
 
+    CURLMcode CURLInterface::multi_add_handle(CURLM* multi_handle, CURLHandle& h)
+    {
+        return curl_multi_add_handle(multi_handle, h.handle());
+    }
+
+    void CURLInterface::multi_remove_handle(CURLM* multihandle, CURLHandle& h)
+    {
+        curl_multi_remove_handle(multihandle, h.handle());
+    }
+
+    bool CURLInterface::handle_is_equal(CURLHandle* h, CURLMsg* msg)
+    {
+        return (h->handle() == msg->easy_handle);
     }
 }

--- a/src/curl_internal.hpp
+++ b/src/curl_internal.hpp
@@ -39,6 +39,9 @@ namespace powerloader
                                  CURLHandle& h);
 
         static bool handle_is_equal(CURLHandle* h, CURLMsg* msg);
+
+        template <class T>
+        static tl::expected<T, CURLcode> get_info_wrapped(CURLHandle& h, CURLINFO option);
     };
 }
 #endif

--- a/src/curl_internal.hpp
+++ b/src/curl_internal.hpp
@@ -23,4 +23,22 @@ namespace powerloader::details
         CURLSetup& operator=(const CURLSetup&) = delete;
     };
 }
+
+namespace powerloader
+{
+    class CURLInterface
+    {
+    public:
+        CURLInterface() = delete;
+        ~CURLInterface() = delete;
+
+        static CURLMcode multi_add_handle(CURLM* multi_handle,
+                                   CURLHandle& h);
+
+        static void multi_remove_handle(CURLM* multihandle,
+                                 CURLHandle& h);
+
+        static bool handle_is_equal(CURLHandle* h, CURLMsg* msg);
+    };
+}
 #endif

--- a/src/downloader.cpp
+++ b/src/downloader.cpp
@@ -23,6 +23,7 @@ namespace fs = std::filesystem;
 #include <powerloader/mirror.hpp>
 #include <powerloader/utils.hpp>
 #include "target.hpp"
+#include "curl_internal.hpp"
 #ifdef WITH_ZCHUNK
 #include "zck.hpp"
 #endif
@@ -514,7 +515,7 @@ namespace powerloader
 
             for (auto* target : m_running_transfers)
             {
-                if (target->curl_handle() && target->curl_handle()->handle() == msg->easy_handle)
+                if (target->curl_handle() && CURLInterface::handle_is_equal(target->curl_handle(), msg))
                 {
                     current_target = target;
                     break;

--- a/src/fastest_mirror.cpp
+++ b/src/fastest_mirror.cpp
@@ -54,9 +54,9 @@ namespace powerloader
             std::size_t handles_added = 0;
             for (auto& el : mirrors)
             {
-                if (el.handle)
+                if (el.handle.handle())
                 {
-                    curl_multi_add_handle(multihandle, el.handle);
+                    curl_multi_add_handle(multihandle, el.handle.handle());
                     handles_added++;
                     spdlog::info("Checking URL: {}", el.url);
                 }
@@ -156,7 +156,7 @@ namespace powerloader
             for (auto& el : mirrors)
             {
                 // Remove handle
-                curl_multi_remove_handle(multihandle, el.handle);
+                curl_multi_remove_handle(multihandle, el.handle.handle());
 
                 // Calculate plain_connect_time
                 auto effective_url = el.handle.getinfo<std::string>(CURLINFO_EFFECTIVE_URL);

--- a/src/fastest_mirror.cpp
+++ b/src/fastest_mirror.cpp
@@ -6,6 +6,8 @@
 #include <powerloader/curl.hpp>
 #include <powerloader/utils.hpp>
 
+#include "curl_internal.hpp"
+
 namespace powerloader
 {
     namespace detail
@@ -54,9 +56,9 @@ namespace powerloader
             std::size_t handles_added = 0;
             for (auto& el : mirrors)
             {
-                if (el.handle.handle())
+                if (el.handle.handle_exists())
                 {
-                    curl_multi_add_handle(multihandle, el.handle.handle());
+                    CURLInterface::multi_add_handle(multihandle, el.handle);
                     handles_added++;
                     spdlog::info("Checking URL: {}", el.url);
                 }
@@ -156,7 +158,7 @@ namespace powerloader
             for (auto& el : mirrors)
             {
                 // Remove handle
-                curl_multi_remove_handle(multihandle, el.handle.handle());
+                CURLInterface::multi_remove_handle(multihandle, el.handle);
 
                 // Calculate plain_connect_time
                 auto effective_url = el.handle.getinfo<std::string>(CURLINFO_EFFECTIVE_URL);

--- a/src/fastest_mirror.cpp
+++ b/src/fastest_mirror.cpp
@@ -161,7 +161,7 @@ namespace powerloader
                 CURLInterface::multi_remove_handle(multihandle, el.handle);
 
                 // Calculate plain_connect_time
-                auto effective_url = el.handle.getinfo<std::string>(CURLINFO_EFFECTIVE_URL);
+                auto effective_url = CURLInterface::get_info_wrapped<std::string>(el.handle, CURLINFO_EFFECTIVE_URL);
 
                 if (!effective_url)
                 {
@@ -177,9 +177,9 @@ namespace powerloader
                 {
                     // Get connect time
                     curl_off_t namelookup_time
-                        = el.handle.getinfo<curl_off_t>(CURLINFO_NAMELOOKUP_TIME_T).value_or(0);
+                        = CURLInterface::get_info_wrapped<curl_off_t>(el.handle, CURLINFO_NAMELOOKUP_TIME_T).value_or(0);
                     curl_off_t connect_time
-                        = el.handle.getinfo<curl_off_t>(CURLINFO_CONNECT_TIME_T).value_or(0);
+                        = CURLInterface::get_info_wrapped<curl_off_t>(el.handle, CURLINFO_CONNECT_TIME_T).value_or(0);
 
                     if (connect_time == 0)
                     {

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -548,7 +548,7 @@ namespace powerloader
             m_mirror->prepare(m_target->path(), h);
             m_state = DownloadState::kPREPARATION;
 
-            CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h);
+            CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h.handle());
             if (cm_rc != CURLM_OK)
             {
                 spdlog::error("curl_multi_add_handle() failed: {}", curl_multi_strerror(cm_rc));
@@ -698,7 +698,7 @@ namespace powerloader
         }
 
         // Add the new handle to the curl multi handle
-        CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h);
+        CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h.handle());
         if (cm_rc != CURLM_OK)
         {
             spdlog::error("curl_multi_add_handle() failed: {}", curl_multi_strerror(cm_rc));

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -64,7 +64,7 @@ namespace powerloader
 
             if (!ec && m_ctx.preserve_filetime)
             {
-                auto remote_filetime = m_curl_handle->getinfo<curl_off_t>(CURLINFO_FILETIME_T);
+                auto remote_filetime = CURLInterface::get_info_wrapped<curl_off_t>(*m_curl_handle, CURLINFO_FILETIME_T);
                 if (!remote_filetime || remote_filetime.value() < 0)
                     spdlog::debug("Unable to get remote time of retrieved document");
 
@@ -170,7 +170,7 @@ namespace powerloader
     std::size_t zckheadercb(char* buffer, std::size_t size, std::size_t nitems, Target* self)
     {
         assert(self && self->m_target);
-        if (self->m_curl_handle->getinfo<long>(CURLINFO_RESPONSE_CODE) == 200)
+        if (CURLInterface::get_info_wrapped<long>(*(self->m_curl_handle), CURLINFO_RESPONSE_CODE) == 200)
         {
             spdlog::info("Too many ranges were attempted in one download");
             self->m_range_fail = 1;

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -1,4 +1,5 @@
 #include "target.hpp"
+#include "curl_internal.hpp"
 
 #ifdef WITH_ZCHUNK
 #include "zck.hpp"
@@ -546,7 +547,7 @@ namespace powerloader
             m_mirror->prepare(m_target->path(), h);
             m_state = DownloadState::kPREPARATION;
 
-            CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h.handle());
+            CURLMcode cm_rc = CURLInterface::multi_add_handle(multi_handle, h);
             if (cm_rc != CURLM_OK)
             {
                 spdlog::error("curl_multi_add_handle() failed: {}", curl_multi_strerror(cm_rc));
@@ -696,7 +697,7 @@ namespace powerloader
         }
 
         // Add the new handle to the curl multi handle
-        CURLMcode cm_rc = curl_multi_add_handle(multi_handle, h.handle());
+        CURLMcode cm_rc = CURLInterface::multi_add_handle(multi_handle, h);
         if (cm_rc != CURLM_OK)
         {
             spdlog::error("curl_multi_add_handle() failed: {}", curl_multi_strerror(cm_rc));

--- a/src/target.cpp
+++ b/src/target.cpp
@@ -169,9 +169,7 @@ namespace powerloader
     std::size_t zckheadercb(char* buffer, std::size_t size, std::size_t nitems, Target* self)
     {
         assert(self && self->m_target);
-        long code = -1;
-        curl_easy_getinfo(self->m_curl_handle->ptr(), CURLINFO_RESPONSE_CODE, &code);
-        if (code == 200)
+        if (self->m_curl_handle->getinfo<long>(CURLINFO_RESPONSE_CODE) == 200)
         {
             spdlog::info("Too many ranges were attempted in one download");
             self->m_range_fail = 1;

--- a/src/target.hpp
+++ b/src/target.hpp
@@ -22,21 +22,6 @@ namespace powerloader
     class Target
     {
     public:
-        /** Header callback for CURL handles.
-         * It parses HTTP and FTP headers and try to find length of the content
-         * (file size of the target). If the size is different then the expected
-         * size, then the transfer is interrupted.
-         * This callback is used only if the expected size is specified.
-         */
-        static std::size_t header_callback(char* buffer,
-                                           std::size_t size,
-                                           std::size_t nitems,
-                                           Target* self);
-        static std::size_t write_callback(char* buffer,
-                                          std::size_t size,
-                                          std::size_t nitems,
-                                          Target* self);
-
         Target(const Context& ctx,
                std::shared_ptr<DownloadTarget> dl_target,
                mirror_set mirrors = {});
@@ -259,6 +244,21 @@ namespace powerloader
                                        std::size_t size,
                                        std::size_t nitems,
                                        Target* self);
+
+        /** Header callback for CURL handles.
+         * It parses HTTP and FTP headers and try to find length of the content
+         * (file size of the target). If the size is different then the expected
+         * size, then the transfer is interrupted.
+         * This callback is used only if the expected size is specified.
+         */
+        static std::size_t header_callback(char* buffer,
+                                           std::size_t size,
+                                           std::size_t nitems,
+                                           Target* self);
+        static std::size_t write_callback(char* buffer,
+                                          std::size_t size,
+                                          std::size_t nitems,
+                                          Target* self);
 
 #ifdef WITH_ZSTD
         std::unique_ptr<ZstdStream> m_zstd_stream;


### PR DESCRIPTION
Fix #159 
It seems like we are using libcurl functions quite everywhere in the code base, so I don't think we can drop libcurl dependency.
I'm opening the PR as a draft to have first feedbacks and discuss if this is how we want to do stuff.