### PR TITLE
Fixed logging not off when set off

### DIFF
--- a/include/powerloader/context.hpp
+++ b/include/powerloader/context.hpp
@@ -8,6 +8,8 @@
 #include <map>
 #include <filesystem>
 
+#include <spdlog/spdlog.h>
+
 #include <powerloader/export.hpp>
 #include <powerloader/mirrorid.hpp>
 #include <powerloader/curl.hpp>
@@ -141,6 +143,7 @@ namespace powerloader
         std::vector<std::string> additional_httpheaders;
 
         void set_verbosity(int v);
+        void set_log_level(spdlog::level::level_enum);
 
         // Throws if another instance already exists: there can only be one at any time!
         Context(ContextOptions options = {});

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -57,7 +57,10 @@ namespace powerloader
     void Context::set_verbosity(int v)
     {
         verbosity = v;
-        if (v > 0)
+        if (v > 2)
+        {
+            spdlog::set_level(spdlog::level::warn);
+        } else if (v > 0)
         {
 #ifdef WITH_ZCHUNK
             zck_set_log_level(ZCK_LOG_DEBUG);
@@ -66,8 +69,20 @@ namespace powerloader
         }
         else
         {
-            spdlog::set_level(spdlog::level::warn);
+            spdlog::set_level(spdlog::level::off);
         }
+    }
+
+
+    void Context::set_log_level(spdlog::level::level_enum log_level)
+    {
+        spdlog::set_level(log_level);
+#ifdef WITH_ZCHUNK
+        if(log_level <= spdlog::level::debug)
+        {
+            zck_set_log_level(ZCK_LOG_DEBUG);
+        }
+#endif
     }
 
     std::string mirror_map_type::to_string() const

--- a/src/context.cpp
+++ b/src/context.cpp
@@ -60,7 +60,8 @@ namespace powerloader
         if (v > 2)
         {
             spdlog::set_level(spdlog::level::warn);
-        } else if (v > 0)
+        }
+        else if (v > 0)
         {
 #ifdef WITH_ZCHUNK
             zck_set_log_level(ZCK_LOG_DEBUG);
@@ -78,7 +79,7 @@ namespace powerloader
     {
         spdlog::set_level(log_level);
 #ifdef WITH_ZCHUNK
-        if(log_level <= spdlog::level::debug)
+        if (log_level <= spdlog::level::debug)
         {
             zck_set_log_level(ZCK_LOG_DEBUG);
         }


### PR DESCRIPTION
We need to be able to set the logs completely off when needed, in particular when libmamba is trying to output only json.